### PR TITLE
MPI.Finalize is called automatically by MPI.jl

### DIFF
--- a/backends/ClimaCommsMPI/src/ClimaCommsMPI.jl
+++ b/backends/ClimaCommsMPI/src/ClimaCommsMPI.jl
@@ -53,9 +53,6 @@ end
 function ClimaComms.init(::Type{MPICommsContext})
     if !MPI.Initialized()
         MPI.Init()
-        atexit() do
-            MPI.Finalize()
-        end
     end
 
     return ClimaComms.mypid(MPICommsContext), ClimaComms.nprocs(MPICommsContext)


### PR DESCRIPTION
This may fix MPI failures on Windows