### PR TITLE
bump versions, increase MPI.jl compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaComms"
 uuid = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/backends/ClimaCommsMPI/Project.toml
+++ b/backends/ClimaCommsMPI/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaCommsMPI"
 uuid = "5f86816e-8b66-43b2-912e-75384f99de49"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
@@ -9,7 +9,7 @@ KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 
 [compat]
-ClimaComms = "0.3"
+ClimaComms = "0.3.1"
 KernelAbstractions = "0.7"
-MPI = "0.19"
+MPI = "0.19, 0.20"
 julia = "1.7"

--- a/backends/ClimaCommsMPI/src/ClimaCommsMPI.jl
+++ b/backends/ClimaCommsMPI/src/ClimaCommsMPI.jl
@@ -157,7 +157,11 @@ function ClimaComms.start(
 end
 
 function ClimaComms.progress(ghost::MPISendRecvGraphContext)
-    MPI.Iprobe(MPI.MPI_ANY_SOURCE, ghost.tag, ghost.ctx.mpicomm)
+    if isdefined(MPI, :MPI_ANY_SOURCE) # < v0.20
+        MPI.Iprobe(MPI.MPI_ANY_SOURCE, ghost.tag, ghost.ctx.mpicomm)
+    else # >= v0.20
+        MPI.Iprobe(MPI.ANY_SOURCE, ghost.tag, ghost.ctx.mpicomm)
+    end
 end
 
 function ClimaComms.finish(

--- a/backends/ClimaCommsMPI/test/runtests.jl
+++ b/backends/ClimaCommsMPI/test/runtests.jl
@@ -1,17 +1,11 @@
-using MPI
-using Test
+using MPI, Test
 
 function runmpi(file; ntasks = 1)
     # Some MPI runtimes complain if more resources are requested
     # than available.
-    if MPI.MPI_LIBRARY == MPI.OpenMPI
-        oversubscribe = `--oversubscribe`
-    else
-        oversubscribe = ``
-    end
     MPI.mpiexec() do cmd
         Base.run(
-            `$cmd $oversubscribe -np $ntasks $(Base.julia_cmd()) --startup-file=no --project=$(Base.active_project()) $file`;
+            `$cmd -n $ntasks $(Base.julia_cmd()) --startup-file=no --project=$(Base.active_project()) $file`;
             wait = true,
         )
         true


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
updates version numbers, allows use with MPI.jl v0.20

(this is separate from #24, which will require MPI.jl v0.20)
## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevent documentation.

-->
