### PR TITLE
Add `device` field to CommsContext

### DIFF
--- a/backends/ClimaCommsMPI/src/ClimaCommsMPI.jl
+++ b/backends/ClimaCommsMPI/src/ClimaCommsMPI.jl
@@ -3,10 +3,17 @@ module ClimaCommsMPI
 using ClimaComms
 using MPI
 
+"""
+    MPICommsContext(device = ClimaComms.CPU())
+
+A MPI communications context, used for distributed runs.
+"""
 struct MPICommsContext <: ClimaComms.AbstractCommsContext
+    device::ClimaComms.AbstractDevice
     mpicomm::MPI.Comm
 end
-MPICommsContext() = MPICommsContext(MPI.COMM_WORLD)
+MPICommsContext(device = ClimaComms.CPU()) =
+    MPICommsContext(device, MPI.COMM_WORLD)
 
 function ClimaComms.init(ctx::MPICommsContext)
     if !MPI.Initialized()

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -14,6 +14,13 @@ ClimaComms.AbstractCommsContext
 ClimaComms.AbstractGraphContext
 ```
 
+### Devices
+```@docs
+ClimaComms.AbstractDevice
+ClimaComms.CPU
+ClimaComms.CUDA
+```
+
 ### Communication interface
 ```@docs
 ClimaComms.init

--- a/src/ClimaComms.jl
+++ b/src/ClimaComms.jl
@@ -17,6 +17,27 @@ Use one of the `ClimaComms` backends, currently:
 module ClimaComms
 
 """
+    AbstractDevice
+
+The base type for a device.
+"""
+abstract type AbstractDevice end
+
+"""
+    CPU()
+
+Run code on a CPU device
+"""
+struct CPU <: AbstractDevice end
+
+"""
+    CUDA()
+
+Use NVIDIA GPU accelarator
+"""
+struct CUDA <: AbstractDevice end
+
+"""
     AbstractCommsContext
 
 The base type for a communications context. Each backend defines a

--- a/src/singleton.jl
+++ b/src/singleton.jl
@@ -1,9 +1,13 @@
 """
-    SingletonCommsContext()
+    SingletonCommsContext(device = CPU())
 
 A singleton communications context, used for single-process runs.
 """
-struct SingletonCommsContext <: AbstractCommsContext end
+struct SingletonCommsContext <: AbstractCommsContext
+    device::AbstractDevice
+end
+
+SingletonCommsContext(device = CPU()) = SingletonCommsContext(device)
 
 init(::SingletonCommsContext) = (1, 1)
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Add `device` field to CommsContext. This will help allocate resources on the appropriate device.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
