### PR TITLE
Fix method redefinition

### DIFF
--- a/src/singleton.jl
+++ b/src/singleton.jl
@@ -4,11 +4,11 @@
 A singleton communications context, used for single-process runs.
 [`ClimaComms.CPU`](@ref) and [`ClimaComms.CUDA`](@ref) device options are currently supported.
 """
-struct SingletonCommsContext <: AbstractCommsContext
-    device::AbstractDevice
+struct SingletonCommsContext{T <: AbstractDevice} <: AbstractCommsContext
+    device::T
 end
 
-SingletonCommsContext(device = CPU()) = SingletonCommsContext(device)
+SingletonCommsContext() = SingletonCommsContext(CPU())
 
 init(::SingletonCommsContext) = (1, 1)
 


### PR DESCRIPTION
This PR
 - fixes the method redefinition in `singleton.jl`
 - adds a concrete type of context into the type space to avoid abstract field names

The method redefinition says:

```
[ Info: Precompiling ClimaCore [d414da3d-4745-48bb-8d80-42e94e092884]
WARNING: Method definition (::Type{ClimaComms.SingletonCommsContext})(Any) in module ClimaComms at \dev\.julia\packages\ClimaComms\3VNKq\src\singleton.jl:11 overwritten at \dev\.julia\packages\ClimaComms\3VNKq\src\singleton.jl:8.
  ** incremental compilation may be fatally broken for this module **
```