### PR TITLE
Check for CUDA-aware MPI on CUDADevice

### DIFF
--- a/src/mpi.jl
+++ b/src/mpi.jl
@@ -16,6 +16,8 @@ end
 MPICommsContext(device = device()) = MPICommsContext(device, MPI.COMM_WORLD)
 
 function init(ctx::MPICommsContext)
+    ctx.device == CUDADevice() &&
+        (@assert MPI.has_cuda() "MPI is not CUDA-aware")
     if !MPI.Initialized()
         MPI.Init()
     end


### PR DESCRIPTION
Check that MPI is CUDA-aware if configured as such


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
