### PR TITLE
Add threaded macro

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,6 +37,15 @@ steps:
       slurm_nodes: 1
       slurm_ntasks_per_node: 4
 
+  - label: ":computer: threaded tests"
+    key: "cpu_threaded_tests"
+    command:
+      - julia --threads 8 --project -e 'using Pkg; Pkg.test()'
+    env:
+      CLIMACOMMS_TEST_DEVICE: CPU
+    agents:
+      slurm_cpus_per_task: 8
+
   - label: ":flower_playing_cards: tests"
     key: "gpu_tests"
     command:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaComms"
 uuid = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -18,6 +18,7 @@ ClimaComms.CPUMultiThreading
 ClimaComms.CUDADevice
 ClimaComms.device
 ClimaComms.array_type
+ClimaComms.@threaded
 ```
 
 ## Contexts

--- a/src/devices.jl
+++ b/src/devices.jl
@@ -79,3 +79,32 @@ The base array type used by the specified device (currently `Array` or `CuArray`
 """
 array_type(::AbstractCPUDevice) = Array
 array_type(::CUDADevice) = CUDA.CuArray
+
+
+"""
+    @threaded device for ... end
+
+A threading macro that uses Julia native threading if the
+device is a `CPUMultiThreaded` type, otherwise return
+the original expression without `Threads.@threads`. This is
+done to avoid overhead from `Threads.@threads`, and the device
+is used (instead of checking `Threads.nthreads() == 1`) so
+that this is statically inferred.
+
+## References
+
+ - https://discourse.julialang.org/t/threads-threads-with-one-thread-how-to-remove-the-overhead/58435
+ - https://discourse.julialang.org/t/overhead-of-threads-threads/53964
+"""
+macro threaded(device, expr)
+    return esc(quote
+        let
+            if $device isa ClimaComms.CPUMultiThreaded
+                Threads.@threads $(expr)
+            else
+                @assert $device isa ClimaComms.CPUSingleThreaded
+                $(expr)
+            end
+        end
+    end)
+end


### PR DESCRIPTION
This PR adds a macro that should allow us to write, for example:

```julia
function byslab(fn, space::Spaces.AbstractSpace)
    byslab(fn, ClimaComms.device(space), space)
end

function byslab(fn, device::ClimaComms.AbstractCPUDevice, space::Spaces.AbstractSpectralElementSpace)
    Nh = Topologies.nlocalelems(space.topology)::Int
    @inbounds begin
        ClimaComms.@threaded device for h in 1:Nh
            fn(SlabIndex(nothing, h))
        end
    end
end
```