### PR TITLE
Extend at-time and at-elapsed

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -19,6 +19,8 @@ ClimaComms.CUDADevice
 ClimaComms.device
 ClimaComms.array_type
 ClimaComms.@threaded
+ClimaComms.@time
+ClimaComms.@elapsed
 ```
 
 ## Contexts

--- a/src/devices.jl
+++ b/src/devices.jl
@@ -102,7 +102,7 @@ macro threaded(device, expr)
         if $(esc(device)) isa CPUMultiThreaded
             Threads.@threads $(expr)
         else
-            @assert $(esc(device)) isa CPUSingleThreaded
+            @assert $(esc(device)) isa AbstractDevice
             $(esc(expr))
         end
     end

--- a/src/devices.jl
+++ b/src/devices.jl
@@ -107,3 +107,55 @@ macro threaded(device, expr)
         end
     end
 end
+
+"""
+    @time device expr
+
+Device-flexible `@time`.
+
+Lowers to
+```julia
+@time expr
+```
+for CPU devices and
+```julia
+CUDA.@time expr
+```
+for CUDA devices.
+"""
+macro time(device, expr)
+    return quote
+        if $(esc(device)) isa CUDADevice
+            CUDA.@time $(esc(expr))
+        else
+            @assert $(esc(device)) isa AbstractDevice
+            Base.@time $(esc(expr))
+        end
+    end
+end
+
+"""
+    @elapsed device expr
+
+Device-flexible `@elapsed`.
+
+Lowers to
+```julia
+@elapsed expr
+```
+for CPU devices and
+```julia
+CUDA.@elapsed expr
+```
+for CUDA devices.
+"""
+macro elapsed(device, expr)
+    return quote
+        if $(esc(device)) isa CUDADevice
+            CUDA.@elapsed $(expr)
+        else
+            @assert $(esc(device)) isa AbstractDevice
+            Base.@elapsed $(expr)
+        end
+    end
+end

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -24,7 +24,7 @@ if haskey(ENV, "CLIMACOMMS_TEST_DEVICE")
 end
 
 using SafeTestsets
-@safetestset "@threaded hygiene" begin
+@safetestset "macro hygiene" begin
     include("hygiene.jl")
 end
 

--- a/test/hygiene.jl
+++ b/test/hygiene.jl
@@ -3,3 +3,11 @@ dev = CC.device()
 CC.@threaded dev for i in 1:2
     1
 end
+
+CC.@time dev for i in 1:2
+    sin.(rand(10))
+end
+
+CC.@elapsed dev for i in 1:2
+    sin.(rand(10))
+end


### PR DESCRIPTION
This PR extends `Base.@time` / `Base.@elapsed` for CPU/CUDA devices.