### PR TITLE
Upgrade to CUDA 11.8

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,13 +1,13 @@
 agents:
   queue: central
   slurm_mem: 8G
-  modules: julia/1.8.5 ucx/1.13.1_cuda-11.2 cuda/11.2 openmpi/4.1.5_cuda-11.2 hdf5/1.14.0-ompi415 nsight-systems/2022.2.1
+  modules: julia/1.8.5 cuda/11.8 ucx/1.14.1_cuda-11.8 openmpi/4.1.5_cuda-11.8 hdf5/1.12.2-ompi415 nsight-systems/2022.2.1
 
 env:
   JULIA_LOAD_PATH: "${JULIA_LOAD_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}/.buildkite"
   JULIA_CUDA_USE_BINARYBUILDER: false
   JULIA_CUDA_MEMORY_POOL: none
-  CUDA_PATH: "/central/software/CUDA/11.2/targets/x86_64-linux" # https://github.com/JuliaGPU/CUDA_Runtime_Discovery.jl/issues/5
+  CUDA_PATH: "/central/software/CUDA/11.8/targets/x86_64-linux" # https://github.com/JuliaGPU/CUDA_Runtime_Discovery.jl/issues/5
   OPENBLAS_NUM_THREADS: 1
 
 steps:


### PR DESCRIPTION
Per:

```
┌ Warning: There are known codegen bugs on CUDA 11.4 and earlier for older GPUs like your NVIDIA Tesla P100-PCIE-16GB.
--
  | │ Please use CUDA 11.5 or later, or switch to a different device.
  | └ @ CUDA /central/scratch/esm/slurm-buildkite/climacomms-ci/87/depot/default/packages/CUDA/tVtYo/lib/cudadrv/state.jl:246
```

in [this build](https://buildkite.com/clima/climacomms-ci/builds/87#018902c3-220c-4c52-b7b4-f2b3867387c2)