### PR TITLE
Fix threaded hygiene, add test

### DIFF
--- a/src/devices.jl
+++ b/src/devices.jl
@@ -98,14 +98,12 @@ that this is statically inferred.
  - https://discourse.julialang.org/t/overhead-of-threads-threads/53964
 """
 macro threaded(device, expr)
-    return esc(quote
-        let
-            if $device isa ClimaComms.CPUMultiThreaded
-                Threads.@threads $(expr)
-            else
-                @assert $device isa ClimaComms.CPUSingleThreaded
-                $(expr)
-            end
+    return quote
+        if $(esc(device)) isa CPUMultiThreaded
+            Threads.@threads $(expr)
+        else
+            @assert $(esc(device)) isa CPUSingleThreaded
+            $(esc(expr))
         end
-    end)
+    end
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,7 @@
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 MPIPreferences = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -23,6 +23,10 @@ if haskey(ENV, "CLIMACOMMS_TEST_DEVICE")
     end
 end
 
+using SafeTestsets
+@safetestset "@threaded hygiene" begin
+    include("hygiene.jl")
+end
 
 if context isa ClimaComms.MPICommsContext
     graph_opt_list = [(; persistent = true), (; persistent = false)]

--- a/test/hygiene.jl
+++ b/test/hygiene.jl
@@ -1,0 +1,5 @@
+import ClimaComms as CC
+dev = CC.device()
+CC.@threaded dev for i in 1:2
+    1
+end


### PR DESCRIPTION
This PR fixes macro hygiene in the `@threaded` macro and adds a test.