### PR TITLE
Extend BenchmarkTools at-benchmark

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,3 +12,6 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 CUDA = "3, 4"
 MPI = "0.20.6"
 julia = "1.8"
+
+[extensions]
+BenchmarkToolsExt = "BenchmarkTools"

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.5.2"
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
 CUDA = "3, 4"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -79,10 +79,10 @@ uuid = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
 version = "0.1.6"
 
 [[deps.ClimaComms]]
-deps = ["CUDA", "MPI"]
+deps = ["CUDA", "MPI", "Requires"]
 path = ".."
 uuid = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
-version = "0.3.5"
+version = "0.5.2"
 
 [[deps.Compat]]
 deps = ["Dates", "LinearAlgebra", "UUIDs"]
@@ -265,9 +265,9 @@ version = "2.28.0+0"
 
 [[deps.MicrosoftMPI_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "a16aa086d335ed7e0170c5265247db29172af2f9"
+git-tree-sha1 = "a8027af3d1743b3bfae34e54872359fdebb31422"
 uuid = "9237b28f-5490-5468-be7b-bb81f5f5e6cf"
-version = "10.1.3+2"
+version = "10.1.3+4"
 
 [[deps.Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"

--- a/ext/BenchmarkToolsExt.jl
+++ b/ext/BenchmarkToolsExt.jl
@@ -1,5 +1,9 @@
+module BenchmarkToolsExt
+
+isdefined(Base, :get_extension) ? (import BenchmarkTools) :
+(import ..BenchmarkTools)
+
 import CUDA
-import .BenchmarkTools
 
 #=
 This file is conditionally loaded
@@ -35,4 +39,6 @@ macro benchmark(device, expr)
             BenchmarkTools.@benchmark $(expr)
         end
     end
+end
+
 end

--- a/src/ClimaComms.jl
+++ b/src/ClimaComms.jl
@@ -13,9 +13,11 @@ module ClimaComms
 
 using Requires
 function __init__()
-    @require BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf" include(
-        joinpath("weak_deps", "benchmark_tools.jl"),
-    )
+    @static if !isdefined(Base, :get_extension)
+        @require BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf" include(
+            joinpath("..", "ext", "BenchmarkToolsExt.jl"),
+        )
+    end
     return nothing
 end
 

--- a/src/ClimaComms.jl
+++ b/src/ClimaComms.jl
@@ -11,6 +11,14 @@ in order to:
 """
 module ClimaComms
 
+using Requires
+function __init__()
+    @require BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf" include(
+        joinpath("weak_deps", "benchmark_tools.jl"),
+    )
+    return nothing
+end
+
 include("devices.jl")
 include("context.jl")
 include("singleton.jl")

--- a/src/weak_deps/benchmark_tools.jl
+++ b/src/weak_deps/benchmark_tools.jl
@@ -1,0 +1,38 @@
+import CUDA
+import .BenchmarkTools
+
+#=
+This file is conditionally loaded
+if BenchmarkTools has been loaded:
+
+```julia
+using BenchmarkTools # to load this file
+using ClimaComms
+```
+=#
+
+"""
+    @benchmark device expr
+
+Device-flexible `@benchmark`.
+
+Lowers to
+```julia
+BenchmarkTools.@benchmark expr
+```
+for CPU devices and
+```julia
+BenchmarkTools.@benchmark CUDA.@async expr
+```
+for CUDA devices.
+"""
+macro benchmark(device, expr)
+    return quote
+        if $(esc(device)) isa CUDADevice
+            BenchmarkTools.@benchmark CUDA.@async $(expr)
+        else
+            @assert $(esc(device)) isa AbstractDevice
+            BenchmarkTools.@benchmark $(expr)
+        end
+    end
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"

--- a/test/hygiene.jl
+++ b/test/hygiene.jl
@@ -1,3 +1,4 @@
+using BenchmarkTools # load src/weak_deps/benchmark_tools.jl
 import ClimaComms as CC
 dev = CC.device()
 CC.@threaded dev for i in 1:2
@@ -9,5 +10,9 @@ CC.@time dev for i in 1:2
 end
 
 CC.@elapsed dev for i in 1:2
+    sin.(rand(10))
+end
+
+CC.@benchmark dev for i in 1:2
     sin.(rand(10))
 end


### PR DESCRIPTION
This PR extends BenchmarkTools `@benchmark` (ref: https://cuda.juliagpu.org/dev/development/profiling/#Time-measurements)