### PR TITLE
Define cuda_sync macro

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ authors = [
     "Jake Bolewski <clima-software@caltech.edu>",
     "Gabriele Bozzola <gbozzola@caltech.edu>",
 ]
-version = "0.5.7"
+version = "0.5.8"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -22,6 +22,7 @@ ClimaComms.@threaded
 ClimaComms.@time
 ClimaComms.@elapsed
 ClimaComms.@sync
+ClimaComms.@cuda_sync
 ```
 
 ## Contexts

--- a/test/hygiene.jl
+++ b/test/hygiene.jl
@@ -18,6 +18,10 @@ function test_macro_hyhiene(dev)
     CC.@sync dev for i in 1:n
         sin.(rand(10))
     end
+
+    CC.@cuda_sync dev for i in 1:n
+        sin.(rand(10))
+    end
 end
 dev = CC.device()
 


### PR DESCRIPTION
This PR defines `ClimaComms.@cuda_sync`, which I think may actually be more useful/commonly needed/helpful than `ClimaComms.@sync`.

I've kind of explained why by updating the docs for `ClimaComms.@sync`.