### PR TITLE
Update climacommon to 2024_05_27

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: new-central
   slurm_mem: 8G
-  modules: climacommon/2024_03_18
+  modules: climacommon/2024_05_27
 
 env:
   OPENBLAS_NUM_THREADS: 1


### PR DESCRIPTION
🤖 Beep boop. I am GabrieleBOT. 🤖

I received an update so that I can inform you directly of the changes (but feel free to check the [release notes](https://github.com/CliMA/ClimaModules/blob/main/NEWS.md)).

Over the weekend, a new version of MPITrampoline was released. This version is incompatible with the version of MPIwrapper we were using, so we had to install a new version of MPIwrapper. The most recent version of climacommon uses this updated version of MPIwrapper.