### PR TITLE
Fix macros

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ authors = [
     "Jake Bolewski <clima-software@caltech.edu>",
     "Gabriele Bozzola <gbozzola@caltech.edu>",
 ]
-version = "0.6.1"
+version = "0.6.2"
 
 [weakdeps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/ext/ClimaCommsCUDAExt.jl
+++ b/ext/ClimaCommsCUDAExt.jl
@@ -3,23 +3,27 @@ module ClimaCommsCUDAExt
 import CUDA
 
 import ClimaComms
+import ClimaComms: CUDADevice
 
-function ClimaComms._assign_device(::ClimaComms.CUDADevice, rank_number)
+function ClimaComms._assign_device(::CUDADevice, rank_number)
     CUDA.device!(rank_number % CUDA.ndevices())
     return nothing
 end
 
-function ClimaComms.device_functional(::ClimaComms.CUDADevice)
+function ClimaComms.device_functional(::CUDADevice)
     return CUDA.functional()
 end
 
-ClimaComms.array_type(::ClimaComms.CUDADevice) = CUDA.CuArray
-ClimaComms.allowscalar(f, ::ClimaComms.CUDADevice, args...; kwargs...) =
+ClimaComms.array_type(::CUDADevice) = CUDA.CuArray
+ClimaComms.allowscalar(f, ::CUDADevice, args...; kwargs...) =
     CUDA.@allowscalar f(args...; kwargs...)
 
 # Extending ClimaComms methods that operate on expressions (cannot use dispatch here)
-ClimaComms.cuda_sync(expr) = CUDA.@sync expr
-ClimaComms.cuda_time(expr) = CUDA.@time expr
-ClimaComms.cuda_elasped(expr) = CUDA.@elapsed expr
+ClimaComms.sync(f::F, ::CUDADevice, args...; kwargs...) where {F} =
+    CUDA.@sync f(args...; kwargs...)
+ClimaComms.time(f::F, ::CUDADevice, args...; kwargs...) where {F} =
+    CUDA.@time f(args...; kwargs...)
+ClimaComms.elapsed(f::F, ::CUDADevice, args...; kwargs...) where {F} =
+    CUDA.@elapsed f(args...; kwargs...)
 
 end

--- a/test/hygiene.jl
+++ b/test/hygiene.jl
@@ -1,5 +1,7 @@
 import ClimaComms as CC
+CC.@import_required_backends
 function test_macro_hyhiene(dev)
+    AT = CC.array_type(dev)
     n = 3 # tests that we can reach variables defined in scope
     CC.@threaded dev for i in 1:n
         if Threads.nthreads() > 1
@@ -7,20 +9,44 @@ function test_macro_hyhiene(dev)
         end
     end
 
+    CC.time(dev) do
+        for i in 1:n
+            sin.(AT(rand(1000, 1000)))
+        end
+    end
+
     CC.@time dev for i in 1:n
-        sin.(rand(10))
+        sin.(AT(rand(1000, 1000)))
+    end
+
+    CC.elapsed(dev) do
+        for i in 1:n
+            sin.(AT(rand(10)))
+        end
     end
 
     CC.@elapsed dev for i in 1:n
-        sin.(rand(10))
+        sin.(AT(rand(10)))
+    end
+
+    CC.sync(dev) do
+        for i in 1:n
+            sin.(AT(rand(10)))
+        end
     end
 
     CC.@sync dev for i in 1:n
-        sin.(rand(10))
+        sin.(AT(rand(10)))
+    end
+
+    CC.cuda_sync(dev) do
+        for i in 1:n
+            sin.(AT(rand(10)))
+        end
     end
 
     CC.@cuda_sync dev for i in 1:n
-        sin.(rand(10))
+        sin.(AT(rand(10)))
     end
 end
 dev = CC.device()


### PR DESCRIPTION
This PR fixes the issues with the macros, introduced in #79.

Using `sin.(AT(rand(1000, 1000)))` in the test suite:

```julia
main
julia> using Revise; include("test/hygiene.jl")
----------- @time
  0.000047 seconds

this branch
julia> using Revise; include("test/hygiene.jl")
----------- @time
  0.046593 seconds (97 CPU allocations: 22.891 MiB, 12.87% gc time) (6 GPU allocations: 45.776 MiB, 0.44% memmgmt time)
```
So, this appears to fix the issue. I'm not sure what the best way to test this.

Part of the reason is that this PR is technically behavior changing in that the macro now makes an argument-less closure, and times (in the case of `@time`) the closure.

I think that this is probably fine and, frankly, we could even eliminate the macro and just make the methods, which are far easier to extend/understand (as there is no hygiene to worry about), user-facing. The purely method-based approaches may be easier to test, too, since we could even check `@which` to ensure that we're calling the extension when we expect.