### PR TITLE
Add device-flexible @assert

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ authors = [
     "Jake Bolewski <clima-software@caltech.edu>",
     "Gabriele Bozzola <gbozzola@caltech.edu>",
 ]
-version = "0.6.3"
+version = "0.6.4"
 
 [weakdeps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -31,6 +31,7 @@ ClimaComms.allowscalar
 ClimaComms.@threaded
 ClimaComms.@time
 ClimaComms.@elapsed
+ClimaComms.@assert
 ClimaComms.@sync
 ClimaComms.@cuda_sync
 ```

--- a/ext/ClimaCommsCUDAExt.jl
+++ b/ext/ClimaCommsCUDAExt.jl
@@ -27,5 +27,7 @@ ClimaComms.time(f::F, ::CUDADevice, args...; kwargs...) where {F} =
     CUDA.@time f(args...; kwargs...)
 ClimaComms.elapsed(f::F, ::CUDADevice, args...; kwargs...) where {F} =
     CUDA.@elapsed f(args...; kwargs...)
+ClimaComms.assert(::CUDADevice, cond::C, text::T) where {C, T} =
+    isnothing(text) ? (CUDA.@cuassert cond()) : (CUDA.@cuassert cond() text())
 
 end

--- a/test/hygiene.jl
+++ b/test/hygiene.jl
@@ -29,6 +29,9 @@ function test_macro_hyhiene(dev)
         sin.(AT(rand(10)))
     end
 
+    CC.@assert dev true
+    CC.@assert dev true "some message: $(true)"
+
     CC.sync(dev) do
         for i in 1:n
             sin.(AT(rand(10)))


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR adds a device-flexible `@assert` macro, which can be used to throw errors from kernels without otherwise triggering allocations or inference failures. For a usage example, see the `column_integral_indefinite!` kernel in CliMA/ClimaCore.jl#1903.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
