### PR TITLE
Add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,24 @@
 # ClimaComms.jl
 
-For CliMA distributed computing.
-
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://CliMA.github.io/ClimaComms.jl/dev)
 [![GitHub Actions status](https://github.com/CliMA/ClimaComms.jl/actions/workflows/OS-Tests.yml/badge.svg)](https://github.com/CliMA/ClimaComms.jl/actions/workflows/OS-Tests.yml)
 [![Buildkite status](https://badge.buildkite.com/e3cbade62b514474b9f6abca474d58e760b9cb7a2545e46ad0.svg?branch=main)](https://buildkite.com/clima/climacomms-ci/builds?branch=main)
+
+`ClimaComms.jl` is a small package to work with diverse computing devices and
+environments (e.g., CPUs/GPUs, single-process/MPI). `ClimaComms.jl` provides
+objects to represent such devices and environments and functions to interact
+with them in a unified way. `ClimaComms.jl` is used extensively through the
+`CliMA` ecosystem to control where and how simulations are run (e.g., on one
+CPU, or on several GPUs using with MPI).
+
+`ClimaComms.jl` supports the following `Device`s:
+- `CPUSingleThreaded`
+- `CPUMultiThreaded` (not actively used)
+- `CUDADevice`
+and `Context`es (i.e., environments for distributed computing):
+- `SingletonCommsContext`
+- `MPICommsContext`
+
+Refer to the [documentation](https://CliMA.github.io/ClimaComms.jl/dev)) for
+more details.
+

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,7 +12,12 @@ makedocs(
     clean = true,
     doctest = true,
     modules = [ClimaComms],
-    pages = Any["Home" => "index.md"],
+    pages = Any[
+        "Home" => "index.md",
+        "Developing with `ClimaComms`" => "internals.md",
+        "Frequently Asked Questions" => "faqs.md",
+        "APIs" => "apis.md",
+    ],
 )
 deploydocs(
     repo = "github.com/CliMA/ClimaComms.jl.git",

--- a/docs/src/apis.md
+++ b/docs/src/apis.md
@@ -1,0 +1,78 @@
+# APIs
+
+```@meta
+CurrentModule = ClimaComms
+```
+
+```@docs
+ClimaComms
+```
+
+## Loading
+
+```@docs
+ClimaComms.@import_required_backends
+ClimaComms.cuda_is_required
+ClimaComms.mpi_is_required
+```
+
+## Devices
+
+```@docs
+ClimaComms.AbstractDevice
+ClimaComms.AbstractCPUDevice
+ClimaComms.CPUSingleThreaded
+ClimaComms.CPUMultiThreaded
+ClimaComms.CUDADevice
+ClimaComms.device
+ClimaComms.device_functional
+ClimaComms.array_type
+ClimaComms.allowscalar
+ClimaComms.@threaded
+ClimaComms.@time
+ClimaComms.@elapsed
+ClimaComms.@assert
+ClimaComms.@sync
+ClimaComms.@cuda_sync
+```
+
+## Contexts
+
+```@docs
+ClimaComms.AbstractCommsContext
+ClimaComms.SingletonCommsContext
+ClimaComms.MPICommsContext
+ClimaComms.AbstractGraphContext
+ClimaComms.context
+ClimaComms.graph_context
+```
+
+## Context operations
+
+```@docs
+ClimaComms.init
+ClimaComms.mypid
+ClimaComms.iamroot
+ClimaComms.nprocs
+ClimaComms.abort
+```
+
+## Collective operations
+
+```@docs
+ClimaComms.barrier
+ClimaComms.reduce
+ClimaComms.reduce!
+ClimaComms.allreduce
+ClimaComms.allreduce!
+ClimaComms.bcast
+```
+
+### Graph exchange
+
+```@docs
+ClimaComms.start
+ClimaComms.progress
+ClimaComms.finish
+```
+

--- a/docs/src/faqs.md
+++ b/docs/src/faqs.md
@@ -1,0 +1,41 @@
+# Frequently Asked Questions
+
+## How do I run my simulation on a GPU?
+
+Set the environment variable `CLIMACOMMS_DEVICE` to `CUDA`. This can be
+accomplished in your Julia script with (at the top)
+```julia
+ENV["CLIMACOMMS_DEVICE"] = "CUDA"
+```
+or calling
+```julia
+export CLIMACOMMS_DEVICE="CUDA"
+```
+in your shell (outside of Julia, no spaces).
+
+## My simulation does not start and crashes with a `MPI` error. I don't want to run with `MPI`. What should I do?
+
+`ClimaComms` tries to be smart and select the best configuration for your run.
+Sometimes, it fails. In this case, you can force `ClimaComms` to ignore `MPI`
+with
+```julia
+ENV["CLIMACOMMS_CONTEXT"] = "SINGLETON"
+```
+at the top of your Julia script or by calling
+```julia
+export CLIMACOMMS_CONTEXT="SINGLETON"
+```
+in your shell (outside of Julia, no spaces).
+
+## My code is saying something about `ClimaComms.@import_required_backends`, what does that mean?
+
+When you are using the environment variables to control the execution of your
+script, `ClimaComms` can detect that some important packages are not loaded. For
+example, `ClimaComms` will emit an error if you set `CLIMACOMMS_DEVICE="CUDA"`
+but do not import `CUDA.jl` in your code.
+
+`ClimaComms` provides a macro, [`ClimaComms.@import_required_backends`](@ref),
+that you can add at the top of your scripts to automatically load the required
+packages when needed. Note, the packages have to be in your Julia environment,
+so you might install packages like ` MPI.jl` and `CUDA.jl`.
+

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,77 +1,63 @@
 # ClimaComms
 
-```@meta
-CurrentModule = ClimaComms
+`ClimaComms.jl` is a small package that provides abstractions for different
+computing devices and environments. `ClimaComms.jl` is use extensively by
+`CliMA` packages to control where and how simulations are run (e.g., one on
+core, on multiple GPUs, et cetera).
+
+This page highlights the most important user-facing `ClimaComms` concepts. If
+you are using `ClimaComms` as a developer, refer to the [Developing with
+`ClimaComms`](@ref) page. For a detailed list of all the functions and objects
+implemented, the [APIs](@ref) page collects all of them.
+
+## `Device`s and `Context`s
+
+The two most important objects in `ClimaComms.jl` are the [`Device`](@ref
+`AbstractDevice`) and the [`Context`](@ref `AbstractCommsContext`).
+
+A `Device` identifies a computing device, a piece of hardware that will be
+executing some code. The `Device`s currently implemented are
+- [`CPUSingleThreaded`](@ref), for a CPU core with a single thread;
+- [`CUDADevice`](@ref), for a single CPU core.
+
+> :warning: [`CPUMultiThreaded`](@ref) is also available, but this device is not
+> actively used or developed.
+
+`Device`s are part of [`Context`](@ref `AbstractCommsContext`)s,
+objects that contain information require for multiple `Device`s to communicate.
+Implemented `Context`s are
+- [`SingletonCommsContext`](@ref), when there is no parallelism;
+- [`MPICommsContext`](@ref), for a MPI-parallelized runs.
+
+To choose a device and a context, most `CliMA` packages use the
+[`device()`](@ref) and [`context()`](@ref) functions. These functions look at
+specific environment variables and set the `device` and `context` accordingly.
+By default, the [`CPUSingleThreaded`](@ref) device is chosen and the context is
+set to [`SingletonCommsContext`](@ref) unless `ClimaComms` detects being run in
+a standard MPI launcher (as `srun` or `mpiexec`).
+
+For example, to run a simulation on a GPU, run `julia` as
+```bash
+export CLIMACOMMS_DEVICE="CUDA"
+export CLIMACOMMS_CONTEXT="SINGLETON"
+# call/open julia as usual
 ```
 
-```@docs
-ClimaComms
+> Note: there might be other ways to control the device and context. Please,
+> refer to the documentation of the specific package to learn more.
+
+## Running with MPI/CUDA
+
+`CliMA` packages do not depend directly on `MPI` or `CUDA`, so, if you want to
+run your simulation in parallel mode and/or on GPUs, you will need to install
+some packages separately.
+
+For parallel simulations, [`MPI.jl`](https://github.com/JuliaParallel/MPI.jl), and
+for GPU runs, [`CUDA.jl`](https://github.com/JuliaGPU/CUDA.jl). You can install
+these packages in your base environment
+```bash
+julia -E "using Pkg; Pkg.add(\"CUDA\"); Pkg.add(\"MPI\")"
 ```
-
-## Loading
-
-```@docs
-ClimaComms.import_required_backends
-ClimaComms.cuda_is_required
-ClimaComms.mpi_is_required
-```
-
-## Devices
-
-```@docs
-ClimaComms.AbstractDevice
-ClimaComms.AbstractCPUDevice
-ClimaComms.CPUSingleThreading
-ClimaComms.CPUMultiThreading
-ClimaComms.CUDADevice
-ClimaComms.device
-ClimaComms.device_functional
-ClimaComms.array_type
-ClimaComms.allowscalar
-ClimaComms.@threaded
-ClimaComms.@time
-ClimaComms.@elapsed
-ClimaComms.@assert
-ClimaComms.@sync
-ClimaComms.@cuda_sync
-```
-
-## Contexts
-
-```@docs
-ClimaComms.AbstractCommsContext
-ClimaComms.SingletonCommsContext
-ClimaComms.MPICommsContext
-ClimaComms.AbstractGraphContext
-ClimaComms.context
-ClimaComms.graph_context
-```
-
-## Context operations
-
-```@docs
-ClimaComms.init
-ClimaComms.mypid
-ClimaComms.iamroot
-ClimaComms.nprocs
-ClimaComms.abort
-```
-
-## Collective operations
-
-```@docs
-ClimaComms.barrier
-ClimaComms.reduce
-ClimaComms.reduce!
-ClimaComms.allreduce
-ClimaComms.allreduce!
-ClimaComms.bcast
-```
-
-### Graph exchange
-
-```@docs
-ClimaComms.start
-ClimaComms.progress
-ClimaComms.finish
-```
+Some packages come with environments that includes all possible backends
+(typically `.buildkite`). You can also consider directly using those
+environments.

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -1,0 +1,148 @@
+# Developing with `ClimaComms`
+
+This page goes into more depth about `ClimaComms` in `CliMA` packages.
+
+First, we will describe what `Device`s and `Context`s are.
+
+### `Device`s
+
+`Device`s identify a specific type of computing hardware (e.g., a CPU/a NVidia
+GPU, et cetera). The `Device`s implemented are
+- [`CPUSingleThreaded`](@ref), for a CPU core with a single thread;
+- [`CUDADevice`](@ref), for a single CUDA GPU.
+
+`Device`s in `ClimaComms` are
+[singletons](https://docs.julialang.org/en/v1/manual/types/#man-singleton-types),
+meaning that they do not contain any data: they are used exclusively to
+determine what implementation of a given function or data structure should be
+used. For example, let us implement a function to allocate an array `what` on
+the CPU or on the GPU depending on the `Device`:
+
+```julia
+import ClimaComms: CPUSingleThreaded, CUDADevice
+import CUDA
+
+function allocate(device::CPUSingleThreaded, what)
+    return Array(what)
+end
+
+function allocate(device::CUDADevice, what)
+    return CUDA.CuArray(what)
+end
+```
+
+If we want to allocate memory on the GPU, we would do something like:
+```julia-repl
+julia> allocate(CUDADevice(), [1, 2, 3])
+CUDA.CuArray([1, 2, 3])
+```
+
+Low-level `CliMA` code often needs to implement different methods for different
+`Device`s (e.g., in [ClimaCore](https://github.com/CliMA/ClimaCore.jl)), but
+this level of specialization is often not required at higher levels.
+
+Higher-level code often interacts with `Device`s through `ClimaComms` functions
+such [`time`](@ref) or [`sync`](@ref). These functions implement device-agnostic
+operations. For instance, the proper way to compute how long a given expression takes to compute is
+```julia
+import ClimaComms: @time
+
+device = ClimaComms.device()  # or the device of interest
+
+@time device my_expr
+```
+This will ensure that the correct time is computed (e.g., the time to run a GPU kernel, and not the time to launch the kernel).
+
+For a complete list of such functions, consult the [APIs](@ref) page.
+
+
+### `Context`s
+
+A `Context` contains the information needed for multiple devices to communicate.
+For simulations with only one device, [`SingletonCommsContext`](@ref) simply
+contains an instance of an [`AbstractDevice`](@ref). For `MPI` simulations, the
+context contains the MPI communicator as well.
+
+`Context`s specify devices and form of parallelism, so they are often passed
+around in both low-level and higher-level code.
+
+`ClimaComms` provide functions that are context-agnostic. For instance,
+[`reduce`](@ref) applies a given function to an array across difference
+processes and collects the result. Let us see an example
+```julia
+import ClimaComms
+ClimaComms.@import_required_backends
+
+context = ClimaComms.context()  # Default context (read from environment variables)
+device = ClimaComms.device(context)  # Default device
+
+mypid, nprocs = ClimaComms.init(context)
+
+ArrayType = ClimaComms.array_type(device)
+
+my_array = mypid * ArrayType([1, 1, 1])
+
+reduced_array = ClimaComms.reduce(context, my_array, +)
+ClimaComms.iamroot(context) && @show reduced_array
+```
+
+[`@import_required_backends`](@ref) is responsible for loading relevant
+libraries, for more information refer to the [Backends and extensions](@ref)
+section.
+
+In this snippet, we obtained the default context from environment variables
+using the [`context`](@ref) function. As developers, we do not know whether this
+code is being run on a single process or multiple, so took the more generic
+stance that the code _might_ be run on several processes. When several processes
+are being used, the same code is being run by parallel Julia instances, each
+with a different process id (`pid`). The line ```julia mypid, nprocs =
+ClimaComms.init(context) ``` assigns different `mypid` to the various processes
+and returns `nprocs` so that we can use this information if needed. This
+function is also responsible for distributing GPUs across processes, if
+relevant.
+
+In this example, we used `mypid` to set up `my_array` in such a way that it
+would be different on different processes. We set up the array with `ArrayType`,
+obtained with [`array_type`](@ref). This function provides the type to allocate
+the array on the correct device (CPU or GPU). Then, we applied [`reduce`](@ref)
+to sum them all. [`reduce`](@ref) collects the result to the _root_ process, the
+one with `pid = 1`. For single-process runs, the only process is also a root
+process.
+
+The code above works independently on the number of processes and over all the
+devices supported by `ClimaComms`.
+
+### Backends and extensions
+
+Except the most basic ones, `ClimaComms` computing devices and contexts are
+implemented as independent backends. For instance, `ClimaComms` provides an
+`AbstractDevice` interface for which `CUDADevice` is an implementation that
+depends on [`CUDA.jl`](https://github.com/JuliaGPU/CUDA.jl). Scripts that use
+`ClimaComms` have to load the packages that power the desired backend (e.g.,
+`CUDA.jl` has to be explicitly loaded if one wants to use `CUDADevice`s).
+
+When using the default context and device (as read from environment variables),
+`ClimaComms` can automatically load the required packages. To instruct
+`ClimaComms` to do, add [`ClimaComms.@import_required_backends`](@ref) at the
+beginning of your scripts. `ClimaComms` can also identify some cases when a
+package is required but not loaded and warn you about it.
+
+Using non-trivial backends might require you to install `CUDA.jl` and/or
+`MPI.jl` in your environment.
+
+> Note: When using [`context`](@ref) to select the context, it is safe to always
+> add [`ClimaComms.@import_required_backends`](@ref) at the top of your scripts.
+> *Do not add* [`ClimaComms.@import_required_backends`](@ref) to library code
+> (i.e., in `src`) because the macro requires dependencies that should not be
+> satisfied in that instance.
+
+Technically, `ClimaComms` backends are implemented in Julia
+[extensions](https://pkgdocs.julialang.org/v1/creating-packages/#Conditional-loading-of-code-in-packages-(Extensions)).
+There are two main reasons for this:
+- optional packages (such as `CUDA` and `MPI`) should not be hard dependencies
+  of `ClimaComms`;
+- implementing code in extensions reduces the loading time for `ClimaComms` and
+  downstream packages because it skips compilation of code that is not needed.
+
+If you are implementing features for `ClimaComms`, make sure that your
+backend-specific code is in a Julia extension (in the `ext` folder).

--- a/src/singleton.jl
+++ b/src/singleton.jl
@@ -2,7 +2,8 @@
     SingletonCommsContext(device=device())
 
 A singleton communications context, used for single-process runs.
-[`ClimaComms.CPU`](@ref) and [`ClimaComms.CUDA`](@ref) device options are currently supported.
+[`ClimaComms.AbstractCPUDevice`](@ref) and [`ClimaComms.CUDADevice`](@ref)
+device options are currently supported.
 """
 struct SingletonCommsContext{D <: AbstractDevice} <: AbstractCommsContext
     device::D


### PR DESCRIPTION
`ClimaComms` is an important package in the `CliMA` ecosystem. In particular, it controls how users select whether to run their simulations on CPU or GPUs. It also introduces the concepts of `device` and `context` that are seen everywhere in our codes. In this PR, I try to start filling this gap.