### PR TITLE
Fix a typo

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -18,7 +18,7 @@ The two most important objects in `ClimaComms.jl` are the [`Device`](@ref
 A `Device` identifies a computing device, a piece of hardware that will be
 executing some code. The `Device`s currently implemented are
 - [`CPUSingleThreaded`](@ref), for a CPU core with a single thread;
-- [`CUDADevice`](@ref), for a single CPU core.
+- [`CUDADevice`](@ref), for a single CUDA-enabled GPU.
 
 > :warning: [`CPUMultiThreaded`](@ref) is also available, but this device is not
 > actively used or developed.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -20,8 +20,8 @@ executing some code. The `Device`s currently implemented are
 - [`CPUSingleThreaded`](@ref), for a CPU core with a single thread;
 - [`CUDADevice`](@ref), for a single CUDA-enabled GPU.
 
-> :warning: [`CPUMultiThreaded`](@ref) is also available, but this device is not
-> actively used or developed.
+!!! warn [`CPUMultiThreaded`](@ref) is also available, but this device is not
+    actively used or developed.
 
 `Device`s are part of [`Context`](@ref `AbstractCommsContext`)s,
 objects that contain information require for multiple `Device`s to communicate.


### PR DESCRIPTION
This PR fixes a small typo on the home page of the ClimaComms documentation.