### PR TITLE
Add `Base.summary(ctx)`, primarily to show MPI state

### DIFF
--- a/docs/src/faqs.md
+++ b/docs/src/faqs.md
@@ -67,3 +67,15 @@ that you can add at the top of your scripts to automatically load the required
 packages when needed. Note, the packages have to be in your Julia environment,
 so you might install packages like ` MPI.jl` and `CUDA.jl`.
 
+## How can I see the MPI state and verify that MPI is set up correctly?
+
+To inspect the current MPI state, use the `summary` function: `print(summary(context))`
+
+The output varies depending on your communication context type:
+
+- `SingletonCommsContext`: Displays basic context information and device type
+- `MPICommsContext`: Shows detailed information including each node's rank.
+
+When using GPU acceleration with `CUDADevice`, the summary additionally includes the device type and UUID.
+
+To test that MPI and CUDA are set up correctly, see [this guide](https://github.com/CliMA/slurm-buildkite?tab=readme-ov-file#testing-cuda-and-mpi-modules).

--- a/ext/ClimaCommsCUDAExt.jl
+++ b/ext/ClimaCommsCUDAExt.jl
@@ -11,6 +11,13 @@ function ClimaComms._assign_device(::CUDADevice, rank_number)
     return nothing
 end
 
+function Base.summary(io::IO, ::CUDADevice)
+    dev = CUDA.device()
+    name = CUDA.name(dev)
+    uuid = CUDA.uuid(dev)
+    return "$name ($uuid)"
+end
+
 function ClimaComms.device_functional(::CUDADevice)
     return CUDA.functional()
 end

--- a/src/devices.jl
+++ b/src/devices.jl
@@ -85,6 +85,8 @@ function device()
     return DeviceConstructor()
 end
 
+Base.summary(io::IO, device::AbstractDevice) = string(device_type())
+
 """
     ClimaComms.array_type(::AbstractDevice)
 

--- a/src/mpi.jl
+++ b/src/mpi.jl
@@ -12,3 +12,17 @@ struct MPICommsContext{D <: AbstractDevice, C} <: AbstractCommsContext
 end
 
 function MPICommsContext end
+
+"""
+    local_communicator(ctx::MPICommsContext)
+
+Internal function to create a new MPI communicator for processes on the same physical node.
+
+Sample Usage:
+```
+ClimaComms.local_communicator(ctx) do local_comm
+    ClimaComms._assign_device(ctx.device, MPI.Comm_rank(local_comm))
+end
+```
+"""
+function local_communicator end

--- a/src/singleton.jl
+++ b/src/singleton.jl
@@ -49,3 +49,8 @@ graph_context(ctx::SingletonCommsContext, args...) = SingletonGraphContext(ctx)
 start(gctx::SingletonGraphContext) = nothing
 progress(gctx::SingletonGraphContext) = nothing
 finish(gctx::SingletonGraphContext) = nothing
+
+function Base.summary(io::IO, ctx::SingletonCommsContext)
+    println(io, "Context: $(nameof(typeof(ctx)))")
+    println(io, "Device: $(typeof(ctx.device))")
+end

--- a/test/logging.jl
+++ b/test/logging.jl
@@ -38,3 +38,23 @@ end
         @test occursin(test_str, log_content)
     end
 end
+
+io = IOBuffer()
+summary(io, ctx)
+summary_str = String(take!(io))
+print(summary_str)
+
+@testset "ClimaComms Summary Tests" begin
+    if ClimaComms.iamroot(ctx)
+        @test contains(summary_str, string(nameof(typeof(ctx))))
+        @test contains(summary_str, string(nameof(typeof(ctx.device))))
+    end
+
+    if ctx isa ClimaComms.MPICommsContext
+        @testset "MPI Context Tests" begin
+            ClimaComms.iamroot(ctx) &&
+                @test contains(summary_str, "Total Processes: $nprocs")
+            @test contains(summary_str, "Rank: $(pid-1)")
+        end
+    end
+end


### PR DESCRIPTION
This PR adds two `summary` functions to give more information to the user about the context. This will be useful for debugging MPI simulations.

Singleton context:
```
Context: SingletonCommsContext
Device: ClimaComms.CPUSingleThreaded
```
MPI Context
```
Context: MPICommsContext
Device: ClimaComms.CPUSingleThreaded
Total Processes: 4
Rank: 3, Node: clima.gps.caltech.edu
Rank: 0, Node: clima.gps.caltech.edu
Rank: 1, Node: clima.gps.caltech.edu
Rank: 2, Node: clima.gps.caltech.edu
```

MPI Context w/ CUDA
```
Context: MPICommsContext
Device: ClimaComms.CUDADevice
Total Processes: 4
Rank: 0, Local Rank: 0, Node: clima.gps.caltech.edu, Device: CUDA.CuDevice(0) (09c6a428-f4ea-8730-fd1c-f3d323d0e161)
Rank: 1, Local Rank: 1, Node: clima.gps.caltech.edu, Device: CUDA.CuDevice(0) (02743130-9954-abbd-7a10-877b693748d6)
Rank: 2, Local Rank: 2, Node: clima.gps.caltech.edu, Device: CUDA.CuDevice(0) (393d0468-49c6-673b-766d-56b816b0710a)
Rank: 3, Local Rank: 3, Node: clima.gps.caltech.edu, Device: CUDA.CuDevice(0) (dc2578fd-6065-eca0-9ba6-dfdaef2ef24f)
```