### PR TITLE
Make the MPI context immutable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ authors = [
     "Jake Bolewski <clima-software@caltech.edu>",
     "Gabriele Bozzola <gbozzola@caltech.edu>",
 ]
-version = "0.6.4"
+version = "0.6.5"
 
 [weakdeps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/src/mpi.jl
+++ b/src/mpi.jl
@@ -6,9 +6,15 @@
 A MPI communications context, used for distributed runs.
 [`AbstractCPUDevice`](@ref) and [`CUDADevice`](@ref) device options are currently supported.
 """
-struct MPICommsContext{D <: AbstractDevice, C} <: AbstractCommsContext
+struct MPICommsContext{D <: AbstractDevice} <: AbstractCommsContext
     device::D
-    mpicomm::C
+    function MPICommsContext(dev::AbstractDevice = device())
+        set_mpicomm!()
+        return new{typeof(dev)}(dev)
+    end
 end
 
 function MPICommsContext end
+
+function set_mpicomm! end
+function mpicomm end


### PR DESCRIPTION
This PR makes the MPI context immutable, by storing the `mpicomm` as a module global parameter.