### PR TITLE
Add logging documentation, `default_logger` function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@ ClimaComms.jl Release Notes
 main
 -------
 
+v0.6.6
+-------
+- Replaced `MPIFileLogger` with `FileLogger` and added an `OnlyRootLogger` logger that silences non-root processes [PR 104](https://github.com/CliMA/ClimaComms.jl/pull/104).
+
 v0.6.5
 -------
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaComms"
 uuid = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
 authors = ["Kiran Pamnany <clima-software@caltech.edu>", "Simon Byrne <simonbyrne@caltech.edu>", "Charles Kawczynski <charliek@caltech.edu>", "Sriharsha Kandala <Sriharsha.kvs@gmail.com>", "Jake Bolewski <clima-software@caltech.edu>", "Gabriele Bozzola <gbozzola@caltech.edu>"]
-version = "0.6.5"
+version = "0.6.6"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.11.2"
+julia_version = "1.11.0"
 manifest_format = "2.0"
-project_hash = "c5b9e727593a1bc35ccae9b71e346465d8a7803c"
+project_hash = "d60839f726bd9115791d1a0807a21b61938765a9"
 
 [[deps.ANSIColoredPrinters]]
 git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,6 @@
 [deps]
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+LoggingExtras = "e6f89c97-d47a-5376-807f-9c37f3926c36"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,6 +15,7 @@ makedocs(
     pages = Any[
         "Home" => "index.md",
         "Developing with `ClimaComms`" => "internals.md",
+        "Logging" => "logging.md",
         "Frequently Asked Questions" => "faqs.md",
         "APIs" => "apis.md",
     ],

--- a/docs/src/apis.md
+++ b/docs/src/apis.md
@@ -49,6 +49,14 @@ ClimaComms.graph_context
 Adapt.adapt_structure(::Type{<:AbstractArray}, ::ClimaComms.AbstractCommsContext)
 ```
 
+## Logging
+
+```@docs
+ClimaComms.OnlyRootLogger
+ClimaComms.MPILogger
+ClimaComms.FileLogger
+```
+
 ## Context operations
 
 ```@docs

--- a/docs/src/logging.md
+++ b/docs/src/logging.md
@@ -1,0 +1,170 @@
+# Logging
+
+## Overview
+
+Logging is a crucial tool for debugging, monitoring, and understanding the behavior of your applications. ClimaComms extends Julia's built-in logging functionality (provided by [`Logging.jl`](https://docs.julialang.org/en/v1/stdlib/Logging/)) to work seamlessly in distributed computing environments, particularly with MPI.
+
+### Julia's Logging System
+
+Julia's standard library provides a flexible logging system through `Logging.jl`. Key concepts include:
+
+- **Logger**: An object that handles log messages, determining how they are formatted and where they are sent
+- **Log Level**: Indicates the severity/importance of a message
+- **Log Record**: Contains the message and associated metadata (level, module, line number, etc.)
+
+The default logger in Julia (as of v1.11) is `Logging.ConsoleLogger()`, which prints messages to the console. You can check your current logger using:
+
+```julia
+using Logging; current_logger()
+```
+
+## ClimaComms Logging Features
+
+ClimaComms builds upon Julia's logging system by providing specialized loggers for distributed computing.
+
+To set any of the loggers below as the global logger, use `Logging.global_logger(logger)`:
+
+```julia
+using ClimaComms, Logging
+
+ctx = ClimaComms.context()
+logger = ClimaComms.OnlyRootLogger(ctx)
+global_logger(logger)
+```
+
+### OnlyRootLogger
+
+`OnlyRootLogger(context)` returns a logger that silences non-root processes.
+If using MPI, this logger is enabled on the first [`ClimaComms.init`](@ref) call.
+
+### FileLogger
+
+`FileLogger(context, log_dir)` writes to `stdout` and to a file `log_dir/output.log` simultaneously.
+If using MPI, the `FileLogger` separates logs by MPI process into different files, so that process `i` will write to the `rank_$i.log` file in the `$log_dir` directory, where `$log_dir` is of your choosing. 
+In this case, `$log_dir/output.log` is a [symbolic link](https://en.wikipedia.org/wiki/Symbolic_link) to the root process logs. 
+In other words, you can always look at `$log_dir/output.log` for the output. Logging to `stdout` can be disabled by setting the keyword argument `log_stdout = false`.
+```julia
+using ClimaComms, Logging
+ctx = ClimaComms.context()
+logger = ClimaComms.FileLogger(ctx, "logs")
+
+with_logger(logger) do
+    @warn "Memory usage high"  # Written to rank-specific log file
+end
+```
+This will output the following in both the REPL and `logs/rank_1.log`:
+```julia
+┌ Warning: Memory usage high
+└ @ Main REPL[6]:2
+```
+
+
+### MPILogger
+
+`MPILogger(context)` adds an MPI rank prefix to all log messages:
+
+```julia
+using ClimaComms, Logging
+ctx = ClimaComms.context()
+logger = MPILogger(ctx)
+
+with_logger(logger) do
+    @info "Processing data..."  # Output: [P1]  Info: Processing data...
+end
+```
+
+## Log Levels
+
+Julia provides four standard log levels, in order of increasing severity:
+
+1. `Debug`: Detailed information for debugging
+2. `Info`: General information about program execution
+3. `Warn`: Warnings about potential issues
+4. `Error`: Error conditions that might still allow the program to continue
+
+See [Julia documentation](https://docs.julialang.org/en/v1/stdlib/Logging/#Log-event-structure) for more detailed information.
+
+You can define custom log levels using `LogLevel`:
+
+```julia
+const Trace = LogLevel(-1000)  # Lower number = less severe
+@macroexpand @logmsg Trace "Very detailed trace message"
+```
+
+To disable all log messages at log levels equal to or less than a given `LogLevel`, use [`Logging.disable_logging(level)`](https://docs.julialang.org/en/v1/stdlib/Logging/#Logging.disable_logging).
+
+## Filtering Log Messages
+
+[LoggingExtras.jl](https://github.com/JuliaLogging/LoggingExtras.jl) provides powerful filtering capabilities through the `EarlyFilteredLogger(filter, logger)`, which takes two arguments:
+
+- `filter(log_args)` is a function which takes in `log_args` and returns a Boolean determining if the message should be logged. `log_args` is a NamedTuple with fields `level`, `_module`, `id` and `group`. Example `filter` functions are provided below in the Common Use Cases.
+- `logger` is any existing logger, such as `Logging.ConsoleLogger()` or `MPILogger(ctx)`.
+
+### Common Use Cases
+
+#### How do I save log output to stdout and a file simultaneously?
+
+`ClimaComms.FileLogger` logs to files and stdout simultaneously.
+For full customization, `LoggingExtras.TeeLogger(loggers)` composes multiple loggers, allowing for multiple loggers at once as shown below. 
+
+```julia
+using Logging, LoggingExtras
+
+io = open("simulation.log", "w")
+loggers = (Logging.ConsoleLogger(stdout), Logging.ConsoleLogger(io))
+tee_logger = LoggingExtras.TeeLogger(loggers)
+
+with_logger(tee_logger) do
+    @warn "Log to stdout and file"
+end
+
+close(io)
+```
+
+#### How do I filter out warning messages?
+
+```@example
+using Logging, LoggingExtras
+
+function no_warnings(log_args)
+    return log_args.level != Logging.Warn
+end
+
+filtered_logger = EarlyFilteredLogger(no_warnings, Logging.current_logger())
+
+with_logger(filtered_logger) do
+    @warn "Hide this warning"
+    @info "Display this message"
+end
+```
+
+#### How do I filter out messages from certain modules?
+
+We can create a custom filter that returns `false` if a log message originates from a list of excluded modules.
+
+The same pattern can be reversed to filter messages only coming from certain modules.
+```
+using Logging, LoggingExtras
+
+module_filter(excluded_modules) = log_args ->
+    !(log_args._module in excluded_modules)
+
+ModuleFilteredLogger(excluded) =
+    EarlyFilteredLogger(module_filter(excluded), Logging.current_logger())
+# To test this logger:
+module TestModule
+    using Logging
+    function log_something()
+        @info "This message will appear"
+    end
+end
+
+excluded = (Main, Base)
+with_logger(ModuleFilteredLogger(excluded)) do
+    @info "Hide this message"
+    TestModule.log_something()
+end
+```
+```julia
+[ Info: This message will appear
+```

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -3,6 +3,24 @@ import Logging, LoggingExtras
 export MPILogger, MPIFileLogger
 
 """
+    OnlyRootLogger()
+    OnlyRootLogger(ctx::AbstractCommsContext)
+
+Return a logger that silences non-root processes.
+    
+If no context is passed, obtain the default context via [`context`](@ref).
+"""
+OnlyRootLogger() = OnlyRootLogger(context())
+
+function OnlyRootLogger(ctx::AbstractCommsContext)
+    if iamroot(ctx)
+        return Logging.ConsoleLogger()
+    else
+        return Logging.NullLogger()
+    end
+end
+
+"""
     MPILogger(context::AbstractCommsContext)
     MPILogger(iostream, context)
     
@@ -24,20 +42,140 @@ function MPILogger(iostream, ctx::AbstractCommsContext)
 end
 
 """
-    MPIFileLogger(context, log_dir)
+    FileLogger(context, log_dir; log_stdout = true, min_level = Logging.Info)
 
 Log MPI ranks to different files within the `log_dir`.
+
+The minimum logging level is set using `min_level`.
+If `log_stdout = true`, root process logs will be sent to stdout as well.
 """
-function MPIFileLogger(
+function FileLogger(
     ctx::AbstractCommsContext,
-    log_dir::AbstractString;
+    log_dir;
+    log_stdout = true,
     min_level::Logging.LogLevel = Logging.Info,
 )
+    return FileLogger(stdout, ctx, log_dir; log_stdout, min_level)
+end
+
+function FileLogger(
+    io::IO,
+    ctx::MPICommsContext,
+    log_dir::AbstractString;
+    log_stdout = true,
+    min_level::Logging.LogLevel = Logging.Info,
+)
+    mpi_log_dir = joinpath(log_dir, "logs")
+    !isdir(mpi_log_dir) && mkpath(mpi_log_dir)
+    ClimaComms.barrier(ctx)  # Ensure that the folder is created
     rank = mypid(ctx)
-    !isdir(log_dir) && mkdir(log_dir)
-    return LoggingExtras.FileLogger(
-        joinpath(log_dir, "rank_$rank.log");
+    filepath = abspath(joinpath(mpi_log_dir, "rank_$rank.log"))
+
+    state = Dict(:logger_used => false)
+
+    function min_level_filter(log_args)
+        if iamroot(ctx) && !state[:logger_used]
+            state[:logger_used] = true
+            symlink_path = abspath(joinpath(log_dir, "output.log"))
+            symlink(filepath, symlink_path)
+        end
+        return log_args.level >= min_level
+    end
+
+    file_logger = LoggingExtras.FormatLogger(
+        format_log,
+        filepath,
         append = true,
         always_flush = true,
     )
+
+    filtered_logger =
+        LoggingExtras.EarlyFilteredLogger(min_level_filter, file_logger)
+
+    if iamroot(ctx) && log_stdout
+        return LoggingExtras.TeeLogger((
+            Logging.ConsoleLogger(io),
+            filtered_logger,
+        ))
+    else
+        return filtered_logger
+    end
+end
+
+function FileLogger(
+    io::IO,
+    ctx::SingletonCommsContext,
+    log_dir::AbstractString;
+    log_stdout = true,
+    min_level::Logging.LogLevel = Logging.Info,
+)
+    !isdir(log_dir) && mkpath(log_dir)
+    filepath = joinpath(log_dir, "output.log")
+
+    function min_level_filter(log_args)
+        return log_args.level >= min_level
+    end
+
+    file_logger = LoggingExtras.FormatLogger(
+        format_log,
+        filepath,
+        append = true,
+        always_flush = true,
+    )
+
+    filtered_logger =
+        LoggingExtras.EarlyFilteredLogger(min_level_filter, file_logger)
+
+    if log_stdout
+        return LoggingExtras.TeeLogger((
+            Logging.ConsoleLogger(io),
+            filtered_logger,
+        ))
+    else
+        return filtered_logger
+    end
+end
+
+"""
+    format_log(io, args)
+
+Format log messages similarly to `Logging.ConsoleLogger` for the FileLogger
+
+Add box decorations for multiline strings, indentation, and bolding.
+"""
+function format_log(io::IO, args)
+    msg = string(args.message)
+    msglines = split(msg, '\n')
+    if !isempty(args.kwargs)
+        for (key, val) in args.kwargs
+            push!(msglines, "$key = $val")
+        end
+    end
+
+    level_prefix = string(args.level)
+
+    for (i, msg) in enumerate(msglines)
+        # Set up the box decoration for multi-line strings
+        boxstr =
+            length(msglines) == 1 ? "[ " :
+            i == 1 ? "┌ " : i < length(msglines) ? "│ " : "└ "
+        printstyled(io, boxstr, bold = true)
+        if i == 1
+            printstyled(io, level_prefix, ": ", bold = true)
+        end
+        indent = i == 1 ? 0 : 2
+        print(io, " "^indent, msg)
+        println(io)
+    end
+end
+
+"""
+    with_tempdir(f::Function)
+
+Call `f` on a temporary directory.
+"""
+function with_tempdir(f::Function, ctx)
+    temp_dir = ClimaComms.iamroot(ctx) ? mktempdir() : nothing
+    temp_dir = ClimaComms.bcast(ctx, temp_dir)
+    return f(temp_dir)
 end

--- a/src/mpi.jl
+++ b/src/mpi.jl
@@ -21,7 +21,7 @@ Internal function to create a new MPI communicator for processes on the same phy
 Sample Usage:
 ```
 ClimaComms.local_communicator(ctx) do local_comm
-    ClimaComms._assign_device(ctx.device, MPI.Comm_rank(local_comm))
+    ClimaComms._assign_device(ClimaComms.device(ctx), MPI.Comm_rank(local_comm))
 end
 ```
 """

--- a/src/singleton.jl
+++ b/src/singleton.jl
@@ -52,5 +52,5 @@ finish(gctx::SingletonGraphContext) = nothing
 
 function Base.summary(io::IO, ctx::SingletonCommsContext)
     println(io, "Context: $(nameof(typeof(ctx)))")
-    println(io, "Device: $(typeof(ctx.device))")
+    println(io, "Device: $(typeof(device(ctx)))")
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,7 @@
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+LoggingExtras = "e6f89c97-d47a-5376-807f-9c37f3926c36"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -257,6 +257,6 @@ import Adapt
     end
 end
 
-@testset "logging" begin
+@testset "Logging" begin
     include("logging.jl")
 end


### PR DESCRIPTION
This is a followup to #100.

Contents
- Added logging documentation found [here](https://clima.github.io/ClimaComms.jl/previews/PR104/logging/), this is a comprehensive page about Julia's logging basics, ClimaComms logging functionality, and some tips on using LoggingExtras directly.
- `default_logger(ctx)`, which just creates a logger that silences non-root processes. This will be useful for exchanging singleton/MPI runs without needing to change the logger. Similar [functionality](https://github.com/CliMA/ClimaAtmos.jl/blob/7bf913f3417114e33131b9632b6ee3030a489f04/src/solver/type_getters.jl#L630) exists in ClimaAtmos already and can now be removed.
- Call `default_logger` during MPI initialization
- `MPIFileLogger` has been replaced with `FileLogger(context, log_dir)`, which writes to stdout and to a file log_dir/output.log simultaneously. If using MPI, the FileLogger separates logs by MPI process into different files, so that process i will write to the logs/rank_$i.log file in the log_dir directory. In this case, log_dir/output.log is a symlink to the root process logs in log_dir/logs/rank_1.log. Logging to stdout can be disabled by setting the keyword argument log_stdout = false.
- Improved testing