### PR TITLE
Extend threaded macro to CUDADevice

### DIFF
--- a/.github/workflows/OS-Tests.yml
+++ b/.github/workflows/OS-Tests.yml
@@ -43,7 +43,7 @@ jobs:
         version: '1.11'
 
     - name: Cache artifacts
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       if: steps.filter.outputs.run_test == 'true'
       env:
         cache-name: cache-artifacts

--- a/ext/ClimaCommsCUDAExt.jl
+++ b/ext/ClimaCommsCUDAExt.jl
@@ -4,7 +4,7 @@ import CUDA
 
 import Adapt
 import ClimaComms
-import ClimaComms: CUDADevice
+import ClimaComms: CUDADevice, threaded
 
 function ClimaComms._assign_device(::CUDADevice, rank_number)
     CUDA.device!(rank_number % CUDA.ndevices())
@@ -49,5 +49,84 @@ ClimaComms.elapsed(f::F, ::CUDADevice, args...; kwargs...) where {F} =
     CUDA.@elapsed f(args...; kwargs...)
 ClimaComms.assert(::CUDADevice, cond::C, text::T) where {C, T} =
     isnothing(text) ? (CUDA.@cuassert cond()) : (CUDA.@cuassert cond() text())
+
+# TODO: Generalize all of the following code to multi-dimensional thread blocks
+# and multiple iterators.
+
+# The number of threads in the kernel being executed by the calling thread.
+threads_in_kernel() = CUDA.blockDim().x * CUDA.gridDim().x
+
+# The index of the calling thread, which is between 1 and threads_in_kernel().
+thread_index() =
+    (CUDA.blockIdx().x - 1) * CUDA.blockDim().x + CUDA.threadIdx().x
+
+# The maximum number of blocks that can fit on the GPU used for this kernel.
+grid_size_limit(kernel) = CUDA.attribute(
+    CUDA.device(kernel.fun.mod.ctx),
+    CUDA.DEVICE_ATTRIBUTE_MAX_GRID_DIM_X,
+)
+
+# Either the first value if it is available, or the maximum number of threads
+# that can fit in one block of this kernel (cuOccupancyMaxPotentialBlockSize).
+# With enough blocks, the latter value will maximize the occupancy of the GPU.
+block_size_limit(max_threads_in_block::Int, _) = max_threads_in_block
+block_size_limit(::Val{:auto}, kernel) =
+    CUDA.launch_configuration(kernel.fun).threads
+
+function threaded(f::F, ::CUDADevice, ::Val, itr; block_size) where {F}
+    length(itr) > 0 || return nothing
+    Base.require_one_based_indexing(itr)
+
+    function call_f_once_from_thread()
+        item_index = thread_index()
+        item_index <= length(itr) && @inbounds f(itr[item_index])
+        return nothing
+    end
+    kernel = CUDA.@cuda launch=false call_f_once_from_thread()
+    max_blocks = grid_size_limit(kernel)
+    max_threads_in_block = block_size_limit(block_size, kernel)
+
+    # If there are too many items, coarsen by the smallest possible amount.
+    length(itr) <= max_blocks * max_threads_in_block ||
+        return threaded(f, CUDADevice(), 1, itr)
+
+    threads_in_block = min(max_threads_in_block, length(itr))
+    blocks = cld(length(itr), threads_in_block)
+    CUDA.@sync kernel(; blocks, threads = threads_in_block)
+end
+
+function threaded(
+    f::F,
+    ::CUDADevice,
+    min_items_in_thread::Int,
+    itr;
+    block_size,
+) where {F}
+    min_items_in_thread > 0 || throw(ArgumentError("`coarsen` is not positive"))
+    length(itr) > 0 || return nothing
+    Base.require_one_based_indexing(itr)
+
+    # Maximize memory coalescing with a "grid-stride loop"; for reference, see
+    # https://developer.nvidia.com/blog/cuda-pro-tip-write-flexible-kernels-grid-stride-loops
+    call_f_multiple_times_from_thread() =
+        for item_index in thread_index():threads_in_kernel():length(itr)
+            @inbounds f(itr[item_index])
+        end
+    kernel = CUDA.@cuda launch=false call_f_multiple_times_from_thread()
+    max_blocks = grid_size_limit(kernel)
+    max_threads_in_block = block_size_limit(block_size, kernel)
+
+    # If there are too many items to use the specified coarsening, increase it
+    # by the smallest possible amount.
+    max_required_threads = cld(length(itr), min_items_in_thread)
+    items_in_thread =
+        max_required_threads <= max_blocks * max_threads_in_block ?
+        min_items_in_thread :
+        cld(length(itr), max_blocks * max_threads_in_block)
+
+    threads_in_block = min(max_threads_in_block, max_required_threads)
+    blocks = cld(length(itr), items_in_thread * threads_in_block)
+    CUDA.@sync kernel(; blocks, threads = threads_in_block)
+end
 
 end

--- a/src/devices.jl
+++ b/src/devices.jl
@@ -102,36 +102,6 @@ Currently used to assign CUDADevices to MPI ranks.
 _assign_device(device, id) = nothing
 
 """
-    @threaded device for ... end
-
-A threading macro that uses Julia native threading if the
-device is a `CPUMultiThreaded` type, otherwise return
-the original expression without `Threads.@threads`. This is
-done to avoid overhead from `Threads.@threads`, and the device
-is used (instead of checking `Threads.nthreads() == 1`) so
-that this is statically inferred.
-
-## References
-
- - https://discourse.julialang.org/t/threads-threads-with-one-thread-how-to-remove-the-overhead/58435
- - https://discourse.julialang.org/t/overhead-of-threads-threads/53964
-"""
-macro threaded(device, loop)
-    quote
-        if $(esc(device)) isa CPUMultiThreaded
-            Threads.@threads $(Expr(
-                loop.head,
-                Expr(loop.args[1].head, esc.(loop.args[1].args)...),
-                esc(loop.args[2]),
-            ))
-        else
-            Base.@assert $(esc(device)) isa AbstractDevice
-            $(esc(loop))
-        end
-    end
-end
-
-"""
     @time f(args...; kwargs...)
 
 Device-flexible `@time`:
@@ -376,3 +346,189 @@ macro assert(device, cond, text = nothing)
 end
 assert(::AbstractCPUDevice, cond::C, text::T) where {C, T} =
     isnothing(text) ? (Base.@assert cond()) : (Base.@assert cond() text())
+
+
+"""
+    @threaded [device] [coarsen=...] [block_size=...] for ... end
+
+Device-flexible generalization of `Threads.@threads`, which distributes the
+iterations of a for-loop across multiple threads, with the option to control
+thread coarsening and GPU kernel configuration. Coarsening makes each thread
+evaluate more than one iteration of the loop, which can improve performance by
+reducing the runtime overhead of launching additional threads (though too much
+coarsening worsens performance because it reduces parallelization). The `device`
+is either inferred by calling `ClimaComms.device()`, or it can be specified
+manually, with the following device-dependent behavior:
+
+ - When `device` is a `CPUSingleThreaded()`, the loop is evaluated as-is. This
+   avoids the runtime overhead of calling `Threads.@threads` with a single
+   thread, and, when the device type is statically inferrable, it also avoids
+   compilation overhead.
+
+ - When `device` is a `CPUMultiThreaded()`, the loop is passed to
+   `Threads.@threads`. This supports three different kinds of "schedulers" for
+   determining how many iterations of the loop to evaluate in each thread:
+     1) (default) a "dynamic" scheduler that changes the number of iterations as
+        new threads are launched,
+     2) a "static" scheduler that evaluates a fixed number of iterations per
+        thread, and
+     3) a "greedy" scheduler that uses a small number of threads, continuously
+        evaluating iterations in each thread until the loop is completed (only
+        available as of Julia 1.11).
+   Setting `coarsen` to `:dynamic` or `:greedy` launches threads with those
+   schedulers. Setting it to `:static` or an integer value launches threads with
+   static scheduling (using `:static` is similar to using `1`, but slightly more
+   performant). To read more about multi-threading, see the documentation for
+   [`Threads.@threads`](https://docs.julialang.org/en/v1/base/multi-threading/#Base.Threads.@threads).
+
+ - When `device` is a `CUDADevice()`, the loop is compiled with `CUDA.@cuda` and
+   run with `CUDA.@sync`. Since CUDA launches all threads at the same time, only
+   static scheduling can be used. Setting `coarsen` to any symbol causes each
+   thread to evaluate a single iteration (default), and setting it to an integer
+   value causes each thread to evaluate that number of iterations (the default
+   is similar to using `1`, but slightly more performant). If the total number
+   of iterations in the loop is extremely large, the specified coarsening may
+   require more threads than can be simultaneously launched on the GPU, in which
+   case the amount of coarsening is automatically increased.
+
+   The optional argument `block_size` is also available for manually specifying
+   the size of each block on a GPU. The default value of `:auto` sets the number
+   of threads in each block to the largest possible value that permits a high
+   GPU "occupancy" (the number of active thread warps in each multiprocessor
+   executing the kernel). An integer can be used instead of `:auto` to override
+   this default value. If the specified value exceeds the total number of
+   threads, it is automatically decreased to avoid idle threads.
+
+NOTE: When a value in the body of the loop has a type that cannot be inferred by
+the compiler, an `InvalidIRError` will be thrown during compilation for a
+`CUDADevice()`. In particular, global variables are not inferrable, so
+`@threaded` must be wrapped in a function whenever it is used in the REPL:
+
+```julia-repl
+julia> a = CUDA.CuArray{Int}(undef, 100); b = similar(a);
+
+julia> threaded_copyto!(a, b) = ClimaComms.@threaded for i in axes(a, 1)
+           a[i] = b[i]
+       end
+threaded_copyto! (generic function with 1 method)
+
+julia> threaded_copyto!(a, b)
+
+julia> ClimaComms.@threaded for i in axes(a, 1)
+           a[i] = b[i]
+       end
+ERROR: InvalidIRError: ...
+```
+
+Moreover, type variables are not inferrable across function boundaries, so types
+used in a threaded loop cannot be precomputed before the loop:
+
+```julia-repl
+julia> threaded_add_epsilon!(a) = ClimaComms.@threaded for i in axes(a, 1)
+           FT = eltype(a)
+           a[i] += eps(FT)
+       end
+threaded_add_epsilon! (generic function with 1 method)
+
+julia> threaded_add_epsilon!(a)
+
+julia> function threaded_add_epsilon!(a)
+           FT = eltype(a)
+           ClimaComms.@threaded for i in axes(a, 1)
+               a[i] += eps(FT)
+           end
+       end
+threaded_add_epsilon! (generic function with 1 method)
+
+julia> threaded_add_epsilon!(a)
+ERROR: InvalidIRError: ...
+```
+
+To fix other kinds of inference issues on GPUs, especially ones brought about by
+indexing into iterators with nonuniform element types, see
+[`UnrolledUtilities.jl`](https://github.com/CliMA/UnrolledUtilities.jl).
+"""
+macro threaded(args...)
+    usage_string = "Usage: @threaded [device] [coarsen=...] [block_size=...] for ... end"
+    n_args = length(args)
+    1 <= n_args <= 3 || throw(ArgumentError(usage_string))
+
+    device_expr = :($ClimaComms.device())
+    coarsen_expr = :(:dynamic)
+    block_size_expr = :(:auto)
+    for arg_number in 1:(n_args - 1)
+        device_or_coarsen_expr = args[arg_number]
+        if Meta.isexpr(device_or_coarsen_expr, :(=))
+            (kwarg_name, kwarg_value) = device_or_coarsen_expr.args
+            if kwarg_name == :coarsen
+                coarsen_expr = kwarg_value
+            elseif kwarg_name == :block_size
+                block_size_expr = kwarg_value
+            else
+                throw(ArgumentError(usage_string))
+            end
+        else
+            arg_number == 1 || throw(ArgumentError(usage_string))
+            device_expr = device_or_coarsen_expr
+        end
+    end
+    if coarsen_expr isa QuoteNode
+        coarsen_expr = :(Val($(coarsen_expr)))
+    end
+    if block_size_expr isa QuoteNode
+        block_size_expr = :(Val($(block_size_expr)))
+    end
+
+    loop_expr = args[n_args]
+    Meta.isexpr(loop_expr, :for) || throw(ArgumentError(usage_string))
+    (var_and_itr_expr, loop_body) = loop_expr.args
+    Meta.isexpr(var_and_itr_expr, :(=)) ||
+        throw(ArgumentError("@threaded does not support nested loops"))
+    (var_expr, itr_expr) = var_and_itr_expr.args
+
+    return quote
+        device = $(esc(device_expr))
+        device isa CPUSingleThreaded ? $(esc(loop_expr)) :
+        threaded(
+            $(esc(var_expr)) -> $(esc(loop_body)),
+            device,
+            $(esc(coarsen_expr)),
+            $(esc(itr_expr));
+            block_size = $(esc(block_size_expr)),
+        )
+    end
+end
+
+threaded(f::F, device, coarsen, itr; gpu_kwargs...) where {F} =
+    threaded(f, device, coarsen, itr) # Drop kwargs that are only used for GPUs.
+
+threaded(f::F, ::CPUMultiThreaded, ::Val{:dynamic}, itr) where {F} =
+    Threads.@threads :dynamic for item in itr
+        f(item)
+    end
+
+threaded(f::F, ::CPUMultiThreaded, ::Val{:static}, itr) where {F} =
+    Threads.@threads :static for item in itr
+        f(item)
+    end
+
+@static if VERSION >= v"1.11"
+    threaded(f::F, ::CPUMultiThreaded, ::Val{:greedy}, itr) where {F} =
+        Threads.@threads :greedy for item in itr
+            f(item)
+        end
+end
+
+function threaded(f::F, ::CPUMultiThreaded, items_in_thread::Int, itr) where {F}
+    items_in_thread > 0 || throw(ArgumentError("`coarsen` is not positive"))
+    Base.require_one_based_indexing(itr)
+
+    threads = cld(length(itr), items_in_thread)
+    Threads.@threads :static for thread_index in 1:threads
+        first_item_index = items_in_thread * (thread_index - 1) + 1
+        last_item_index = items_in_thread * thread_index
+        for item_index in first_item_index:min(last_item_index, length(itr))
+            @inbounds f(itr[item_index])
+        end
+    end
+end

--- a/test/hygiene.jl
+++ b/test/hygiene.jl
@@ -3,10 +3,10 @@ CC.@import_required_backends
 function test_macro_hyhiene(dev)
     AT = CC.array_type(dev)
     n = 3 # tests that we can reach variables defined in scope
+
+    array = AT(rand(10))
     CC.@threaded dev for i in 1:n
-        if Threads.nthreads() > 1
-            @show Threads.threadid()
-        end
+        array[i] = sin(array[i])
     end
 
     CC.time(dev) do

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -228,6 +228,41 @@ end
     @test x == Array(a)[1]
 end
 
+@testset "threaded" begin
+    a = AT(rand(100))
+    b = AT(rand(100))
+
+    kernel1!(a, b) = ClimaComms.@threaded for i in axes(a, 1)
+        a[i] = b[i]
+    end
+    kernel1!(a, b)
+    @test a == b
+
+    kernel2!(a, b) = ClimaComms.@threaded coarsen=:static for i in axes(a, 1)
+        a[i] = 2 * b[i]
+    end
+    kernel2!(a, b)
+    @test a == 2 * b
+
+    kernel3!(a, b) = ClimaComms.@threaded device coarsen=3 for i in axes(a, 1)
+        a[i] = 3 * b[i]
+    end
+    kernel3!(a, b)
+    @test a == 3 * b
+
+    kernel4!(a, b) = ClimaComms.@threaded device coarsen=400 for i in axes(a, 1)
+        a[i] = 4 * b[i]
+    end
+    kernel4!(a, b)
+    @test a == 4 * b
+
+    kernel5!(a, b) = ClimaComms.@threaded block_size=50 for i in axes(a, 1)
+        a[i] = 5 * b[i]
+    end
+    kernel5!(a, b)
+    @test a == 5 * b
+end
+
 import Adapt
 @testset "Adapt" begin
     @test Adapt.adapt(Array, ClimaComms.CUDADevice()) ==


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR extends `ClimaComms.@threaded` to work with `CUDADevice`, and it adds an option to control thread coarsening. This will allow us to implement simple kernels in a device-agnostic way (i.e., without needing to explicitly import CUDA). In particular, this functionality is needed to implement LU factorization and LU solver kernels in CliMA/ClimaAtmos.jl#2730. It can also be used to generalize most of the kernels defined in `ClimaCoreCUDAExt.jl` to multi-threaded CPUs.

The current implementation of this macro only performs simple one-dimensional parallelization, but it can be extended to support shared memory and multi-dimensional thread/block configurations in the future. Eventually, we might be able to eliminate CUDA extensions from other packages altogether, replacing them with device-agnostic macros from ClimaComms. The main benefit of this will be that all of our kernel code is defined in one location, with clear documentation that informs developers about important design patterns.

This PR also bumps the version of the cache action in the test-os workflow from `v1` to `v4`, since an error was being thrown for `v1`.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
