### PR TITLE
Extend threaded macro to support lazy iterators

### DIFF
--- a/docs/src/apis.md
+++ b/docs/src/apis.md
@@ -28,13 +28,16 @@ ClimaComms.device
 ClimaComms.device_functional
 ClimaComms.array_type
 ClimaComms.allowscalar
-ClimaComms.@threaded
 ClimaComms.@time
 ClimaComms.@elapsed
 ClimaComms.@assert
 ClimaComms.@sync
 ClimaComms.@cuda_sync
 Adapt.adapt_structure(::Type{<:AbstractArray}, ::ClimaComms.AbstractDevice)
+ClimaComms.@threaded
+ClimaComms.threaded
+ClimaComms.threadable
+ClimaComms.ThreadableWrapper
 ```
 
 ## Contexts

--- a/src/devices.jl
+++ b/src/devices.jl
@@ -1,4 +1,5 @@
 import ..ClimaComms
+import Adapt
 
 """
     AbstractDevice
@@ -399,6 +400,15 @@ manually, with the following device-dependent behavior:
    this default value. If the specified value exceeds the total number of
    threads, it is automatically decreased to avoid idle threads.
 
+Any iterator with methods for `firstindex`, `length`, and `getindex` can be used
+in a `@threaded` loop. All lazy iterators from `Base` and `Base.Iterators`, such
+as `zip`, `enumerate`, `Iterators.product`, and generator expressions, are also
+compatible with `@threaded`. (Although these iterators do not define methods for
+`getindex`, they are automatically modified by `threadable` to support
+`getindex`.) Using multiple iterators with `@threaded` is equivalent to looping
+over a single `Iterators.product`, with the innermost iterator of the loop
+appearing first in the product, and the outermost iterator appearing last.
+
 NOTE: When a value in the body of the loop has a type that cannot be inferred by
 the compiler, an `InvalidIRError` will be thrown during compilation for a
 `CUDADevice()`. In particular, global variables are not inferrable, so
@@ -450,85 +460,271 @@ indexing into iterators with nonuniform element types, see
 """
 macro threaded(args...)
     usage_string = "Usage: @threaded [device] [coarsen=...] [block_size=...] for ... end"
-    n_args = length(args)
-    1 <= n_args <= 3 || throw(ArgumentError(usage_string))
+    (device_and_kwarg_exprs..., loop_block_expr) = args
 
-    device_expr = :($ClimaComms.device())
-    coarsen_expr = :(:dynamic)
-    block_size_expr = :(:auto)
-    for arg_number in 1:(n_args - 1)
-        device_or_coarsen_expr = args[arg_number]
-        if Meta.isexpr(device_or_coarsen_expr, :(=))
-            (kwarg_name, kwarg_value) = device_or_coarsen_expr.args
-            if kwarg_name == :coarsen
-                coarsen_expr = kwarg_value
-            elseif kwarg_name == :block_size
-                block_size_expr = kwarg_value
-            else
-                throw(ArgumentError(usage_string))
-            end
-        else
-            arg_number == 1 || throw(ArgumentError(usage_string))
-            device_expr = device_or_coarsen_expr
+    if all(expr -> Meta.isexpr(expr, :(=)), device_and_kwarg_exprs)
+        device_expr = :($ClimaComms.device())
+        kwarg_exprs = device_and_kwarg_exprs
+    elseif all(expr -> Meta.isexpr(expr, :(=)), device_and_kwarg_exprs[2:end])
+        (device_expr, kwarg_exprs...) = device_and_kwarg_exprs
+    else
+        throw(ArgumentError(usage_string))
+    end
+    for kwarg_expr in kwarg_exprs
+        if kwarg_expr.args[2] isa QuoteNode
+            kwarg_expr.args[2] = :(Val($(kwarg_expr.args[2])))
         end
     end
-    if coarsen_expr isa QuoteNode
-        coarsen_expr = :(Val($(coarsen_expr)))
-    end
-    if block_size_expr isa QuoteNode
-        block_size_expr = :(Val($(block_size_expr)))
-    end
 
-    loop_expr = args[n_args]
-    Meta.isexpr(loop_expr, :for) || throw(ArgumentError(usage_string))
+    loop_expr = if Meta.isexpr(loop_block_expr, :for)
+        loop_block_expr
+    elseif (
+        Meta.isexpr(loop_block_expr, :block) &&
+        length(loop_block_expr.args) == 2 &&
+        Meta.isexpr(loop_block_expr.args[2], :for)
+    )
+        loop_block_expr.args[2]
+    else
+        throw(ArgumentError(usage_string))
+    end
     (var_and_itr_expr, loop_body) = loop_expr.args
-    Meta.isexpr(var_and_itr_expr, :(=)) ||
-        throw(ArgumentError("@threaded does not support nested loops"))
-    (var_expr, itr_expr) = var_and_itr_expr.args
+    if Meta.isexpr(var_and_itr_expr, :(=))
+        var_exprs = Any[var_and_itr_expr.args[1]]
+        itr_exprs = Any[var_and_itr_expr.args[2]]
+    elseif (
+        Meta.isexpr(var_and_itr_expr, :block) &&
+        all(expr -> Meta.isexpr(expr, :(=)), var_and_itr_expr.args)
+    )
+        # Reverse the order of iterators to match standard for-loop behavior
+        # (for-loops go from outermost iterator to innermost iterator, whereas
+        # Iterators.product goes from innermost iterator to outermost iterator).
+        var_exprs =
+            Base.mapany(expr -> expr.args[1], reverse(var_and_itr_expr.args))
+        itr_exprs =
+            Base.mapany(expr -> expr.args[2], reverse(var_and_itr_expr.args))
+    else
+        throw(ArgumentError("Invalid for-loop expression: $var_and_itr_expr"))
+    end
 
+    # Improve latency by inlining the loop on single-threaded CPU devices.
     return quote
         device = $(esc(device_expr))
         device isa CPUSingleThreaded ? $(esc(loop_expr)) :
         threaded(
-            $(esc(var_expr)) -> $(esc(loop_body)),
+            ($(Base.mapany(esc, var_exprs)...),) -> $(esc(loop_body)),
             device,
-            $(esc(coarsen_expr)),
-            $(esc(itr_expr));
-            block_size = $(esc(block_size_expr)),
+            $(Base.mapany(esc, itr_exprs)...);
+            $(Base.mapany(esc, kwarg_exprs)...),
         )
     end
 end
 
-threaded(f::F, device, coarsen, itr; gpu_kwargs...) where {F} =
-    threaded(f, device, coarsen, itr) # Drop kwargs that are only used for GPUs.
+"""
+    threaded(f, device, itrs...; kwargs...)
 
-threaded(f::F, ::CPUMultiThreaded, ::Val{:dynamic}, itr) where {F} =
+Functional form of `@threaded`. If there are `n` iterators and `f` is a function
+of `n` arguments, the `threaded` function is similar to
+
+```julia
+@threaded device [kwargs...] for xₙ in itrs[n], ..., x₂ in itrs[2], x₁ in itrs[1]
+    f(x₁, x₂, ..., xₙ)
+end
+```
+
+On single-threaded CPU devices, the `@threaded` macro inlines the for-loop
+without any intermediate function calls, so that it has a lower latency than the
+`threaded` function. On other devices, the only difference between the macro and
+the function is that keyword argument symbols like `:dynamic` and `:auto` must
+be wrapped in `Val`s for the function.
+"""
+threaded(f::F, device, itrs...; kwargs...) where {F} =
+    threaded(splat(f), device, Iterators.product(itrs...); kwargs...)
+
+threaded(
+    f::F,
+    device,
+    itr;
+    coarsen = Val(:dynamic),
+    block_size = Val(:auto),
+) where {F} =
+    run_threaded(f, device, coarsen, threadable(device, itr); block_size)
+
+run_threaded(f::F, device::AbstractCPUDevice, coarsen, itr; _...) where {F} =
+    run_threaded(f, device, coarsen, itr)
+
+run_threaded(f::F, ::CPUSingleThreaded, _, itr) where {F} =
+    for item in itr
+        f(item)
+    end
+
+run_threaded(f::F, ::CPUMultiThreaded, ::Val{:dynamic}, itr) where {F} =
     Threads.@threads :dynamic for item in itr
         f(item)
     end
 
-threaded(f::F, ::CPUMultiThreaded, ::Val{:static}, itr) where {F} =
+run_threaded(f::F, ::CPUMultiThreaded, ::Val{:static}, itr) where {F} =
     Threads.@threads :static for item in itr
         f(item)
     end
 
 @static if VERSION >= v"1.11"
-    threaded(f::F, ::CPUMultiThreaded, ::Val{:greedy}, itr) where {F} =
+    run_threaded(f::F, ::CPUMultiThreaded, ::Val{:greedy}, itr) where {F} =
         Threads.@threads :greedy for item in itr
             f(item)
         end
 end
 
-function threaded(f::F, ::CPUMultiThreaded, items_in_thread::Int, itr) where {F}
+function run_threaded(
+    f::F,
+    ::CPUMultiThreaded,
+    items_in_thread::Int,
+    itr,
+) where {F}
     items_in_thread > 0 || throw(ArgumentError("`coarsen` is not positive"))
-    Base.require_one_based_indexing(itr)
-
-    threads = cld(length(itr), items_in_thread)
-    Threads.@threads :static for thread_index in 1:threads
+    n_items = length(itr)
+    Threads.@threads :static for thread_index in 1:cld(n_items, items_in_thread)
         first_item_index = items_in_thread * (thread_index - 1) + 1
         last_item_index = items_in_thread * thread_index
-        for item_index in first_item_index:min(last_item_index, length(itr))
-            @inbounds f(itr[item_index])
+        for item_index in first_item_index:min(last_item_index, n_items)
+            @inbounds f(itr[firstindex(itr) + item_index - 1])
         end
     end
 end
+
+"""
+    threadable(device, itr)
+
+Modifies an iterator to ensure that it can be used in a `@threaded` loop. This
+will typically return `itr` or a `ThreadableWrapper` of `itr`.
+"""
+threadable(_, itr) = itr
+
+"""
+    ThreadableWrapper
+
+Wrapper for an iterator from `Base` or `Iterators` that can be used in
+`@threaded`, with methods for `firstindex`, `length`, and `getindex`. The
+`getindex` method only supports linear indices between `firstindex` and
+`firstindex + length - 1`. For the `ThreadableWrapper` of `Iterators.product`,
+`getindex` converts each linear index to a Cartesian index using regular integer
+division on CPUs and `Base.multiplicativeinverse` on GPUs.
+"""
+abstract type ThreadableWrapper end
+Base.firstindex(::ThreadableWrapper) = 1
+Base.iterate(wrapper::ThreadableWrapper, state = 1) =
+    state > length(wrapper) ? nothing : (wrapper[state], state + 1)
+
+struct ThreadableGenerator{F, I} <: ThreadableWrapper
+    f::F
+    itr::I
+end
+Adapt.@adapt_structure ThreadableGenerator
+threadable(device, (; f, iter)::Base.Generator) =
+    ThreadableGenerator(f, threadable(device, iter))
+Base.length((; itr)::ThreadableGenerator) = length(itr)
+Base.@propagate_inbounds Base.getindex(
+    (; f, itr)::ThreadableGenerator,
+    i::Integer,
+) = f(itr[firstindex(itr) + i - 1])
+
+struct ThreadableReverse{I} <: ThreadableWrapper
+    itr::I
+end
+Adapt.@adapt_structure ThreadableReverse
+threadable(device, (; itr)::Iterators.Reverse) =
+    ThreadableReverse(threadable(device, itr))
+Base.length((; itr)::ThreadableReverse) = length(itr)
+Base.@propagate_inbounds Base.getindex((; itr)::ThreadableReverse, i::Integer) =
+    itr[firstindex(itr) + length(itr) - i]
+
+struct ThreadableEnumerate{I} <: ThreadableWrapper
+    itr::I
+end
+Adapt.@adapt_structure ThreadableEnumerate
+threadable(device, (; itr)::Iterators.Enumerate) =
+    ThreadableEnumerate(threadable(device, itr))
+Base.length((; itr)::ThreadableEnumerate) = length(itr)
+Base.@propagate_inbounds Base.getindex(
+    (; itr)::ThreadableEnumerate,
+    i::Integer,
+) = (i, itr[firstindex(itr) + i - 1])
+
+struct ThreadableZip{I} <: ThreadableWrapper
+    itrs::I
+end
+Adapt.@adapt_structure ThreadableZip
+threadable(device, (; is)::Iterators.Zip) =
+    ThreadableZip(map(itr -> threadable(device, itr), is))
+Base.length((; itrs)::ThreadableZip) = minimum(length, itrs)
+Base.@propagate_inbounds Base.getindex((; itrs)::ThreadableZip, i::Integer) =
+    map(itr -> itr[firstindex(itr) + i - 1], itrs)
+
+struct ThreadableProduct{I, D} <: ThreadableWrapper
+    itrs::I
+    divisors::D
+end
+Adapt.@adapt_structure ThreadableProduct
+function threadable(device, (; iterators)::Iterators.ProductIterator)
+    itrs = map(itr -> threadable(device, itr), iterators)
+    divisors = reverse(cumprod((1, map(length, itrs[1:(end - 1)])...)))
+    device_optimized_divisors =
+        device isa AbstractCPUDevice ? divisors :
+        map(Base.multiplicativeinverse, divisors) # Avoid Int division on GPUs.
+    return ThreadableProduct(itrs, device_optimized_divisors)
+end
+Base.length((; itrs)::ThreadableProduct) = prod(length, itrs)
+Base.@propagate_inbounds function Base.getindex(
+    (; itrs, divisors)::ThreadableProduct,
+    i::Integer,
+)
+    reversed_offset_remainder_pairs =
+        accumulate(divisors; init = (0, i - 1)) do (_, remainder), divisor
+            divrem(remainder, divisor)
+        end
+    offsets = map(first, reverse(reversed_offset_remainder_pairs))
+    return map((itr, offset) -> itr[firstindex(itr) + offset], itrs, offsets)
+end
+
+struct ThreadableFlatten{I, O} <: ThreadableWrapper
+    itrs::I
+    offsets::O
+end
+Adapt.@adapt_structure ThreadableFlatten
+function threadable(device, (; it)::Iterators.Flatten)
+    itrs = map(itr -> threadable(device, itr), it)
+    offsets = cumsum((0, map(length, itrs[1:(end - 1)])...))
+    return ThreadableFlatten(itrs, offsets)
+end
+Base.length((; itrs)::ThreadableFlatten) = sum(length, itrs)
+Base.@propagate_inbounds function Base.getindex(
+    (; itrs, offsets)::ThreadableFlatten,
+    i::Integer,
+)
+    # TODO: Implement binary search (searchsortedfirst doesn't work for tuples).
+    n = 0
+    while n < length(offsets) && i > offsets[n + 1]
+        n += 1
+    end
+    return itrs[n][firstindex(itrs[n]) - offsets[n] + i - 1]
+end
+
+struct ThreadablePartition{I} <: ThreadableWrapper
+    itr::I
+    partition_size::Int
+end
+Adapt.@adapt_structure ThreadablePartition
+threadable(device, (; c, n)::Iterators.PartitionIterator) =
+    ThreadablePartition(threadable(device, c), n)
+Base.length((; itr, partition_size)::ThreadablePartition) =
+    cld(length(itr), partition_size)
+Base.@propagate_inbounds function Base.getindex(
+    (; itr, partition_size)::ThreadablePartition,
+    i::Integer,
+)
+    first_index_in_partition = firstindex(itr) + (i - 1) * partition_size
+    last_index_in_partition =
+        firstindex(itr) + min(i * partition_size, length(itr)) - 1
+    return (itr[i] for i in first_index_in_partition:last_index_in_partition)
+end
+
+# TODO: Check whether conversion of every Int to Int32 improves GPU performance.

--- a/test/threaded_benchmark.jl
+++ b/test/threaded_benchmark.jl
@@ -1,0 +1,130 @@
+using ClimaComms
+
+ClimaComms.@import_required_backends
+
+context = ClimaComms.context()
+pid, nprocs = ClimaComms.init(context)
+device = ClimaComms.device(context)
+AT = ClimaComms.array_type(device)
+
+x_max = 100
+y_max = device isa ClimaComms.CUDADevice ? 1000000 : 10000
+a = AT(rand(x_max, y_max))
+∂ⁿa∂xⁿ = similar(a)
+
+Base.@propagate_inbounds function nth_deriv_along_axis1(array, n, i, indices...)
+    @assert n >= 0
+    n == 0 && return array[i, indices...]
+    prev_i = i == 1 ? size(array, 1) : i - 1
+    next_i = i == size(array, 1) ? 1 : i + 1
+    value_at_prev_i = nth_deriv_along_axis1(array, n - 1, prev_i, indices...)
+    value_at_next_i = nth_deriv_along_axis1(array, n - 1, next_i, indices...)
+    value_at_i = nth_deriv_along_axis1(array, n - 1, i, indices...)
+    return (value_at_next_i - 2 * value_at_i + value_at_prev_i) / 2
+end
+
+function print_time_and_bandwidth(device, reads_and_writes, time)
+    @info "    Time = $(round(time; sigdigits = 3)) s"
+    if device isa ClimaComms.CUDADevice
+        cuda_device = CUDA.device()
+        memory_bits_attr = CUDA.DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH
+        memory_kilohertz_attr = CUDA.DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE
+        peak_bandwidth_gbps =
+            (CUDA.attribute(cuda_device, memory_bits_attr) / (8 * 1024^3)) *
+            (CUDA.attribute(cuda_device, memory_kilohertz_attr) * 1000)
+        actual_bandwidth_gbps = (reads_and_writes / 1024^3) / time
+        bandwidth_percent = 100 * actual_bandwidth_gbps / peak_bandwidth_gbps
+        @info "    Bandwidth = $(round(bandwidth_percent; sigdigits = 3))% of \
+                   $(round(peak_bandwidth_gbps; sigdigits = 3)) GB/s"
+    end
+end
+
+@info "Benchmarking n-th derivative along first axis of a $x_max×$y_max matrix"
+
+identity_copy_reference!(∂ⁿa∂xⁿ, a, device) =
+    ClimaComms.@cuda_sync device ∂ⁿa∂xⁿ .= a
+ident_first_time = @elapsed identity_copy_reference!(∂ⁿa∂xⁿ, a, device)
+ident_time = @elapsed identity_copy_reference!(∂ⁿa∂xⁿ, a, device)
+@info "reference identity copy, n = 0:"
+@info "    Latency = $(round(ident_first_time - ident_time; sigdigits = 3)) s"
+print_time_and_bandwidth(device, 2 * sizeof(a), ident_time)
+
+identity_copy!(∂ⁿa∂xⁿ, a, device) = ClimaComms.@cuda_sync device begin
+    ClimaComms.@threaded device for y in axes(a, 2), x in axes(a, 1)
+        @inbounds ∂ⁿa∂xⁿ[x, y] = a[x, y]
+    end
+end
+ident_first_time = @elapsed identity_copy_reference!(∂ⁿa∂xⁿ, a, device)
+ident_time = @elapsed identity_copy_reference!(∂ⁿa∂xⁿ, a, device)
+@info "@threaded identity copy, n = 0:"
+@info "    Latency = $(round(ident_first_time - ident_time; sigdigits = 3)) s"
+print_time_and_bandwidth(device, 2 * sizeof(a), ident_time)
+
+xy_pairs = AT(CartesianIndices(a))
+nth_deriv_by_col_reference!(∂ⁿa∂xⁿ, a, device, n, xy_pairs) =
+    ClimaComms.@cuda_sync device begin
+        ∂ⁿa∂xⁿ .=
+            (pair -> nth_deriv_along_axis1(a, n, pair[1], pair[2])).(xy_pairs)
+    end
+for n in (0, 2, 6)
+    if n == 0
+        first_time =
+            @elapsed nth_deriv_by_col_reference!(∂ⁿa∂xⁿ, a, device, n, xy_pairs)
+    end
+    time = @elapsed nth_deriv_by_col_reference!(∂ⁿa∂xⁿ, a, device, n, xy_pairs)
+    @info "reference derivative (broadcast over matrix of indices), n = $n:"
+    n == 0 && @info "    Latency = $(round(first_time - time; sigdigits = 3)) s"
+    print_time_and_bandwidth(device, 2 * sizeof(a), time)
+end
+
+nth_deriv_by_col!(∂ⁿa∂xⁿ, a, device, n) = ClimaComms.@cuda_sync device begin
+    ClimaComms.@threaded device for y in axes(a, 2), x in axes(a, 1)
+        @inbounds ∂ⁿa∂xⁿ[x, y] = nth_deriv_along_axis1(a, n, x, y)
+    end
+end
+for n in (0, 2, 6)
+    if n == 0
+        first_time = @elapsed nth_deriv_by_col!(∂ⁿa∂xⁿ, a, device, n)
+    end
+    time = @elapsed nth_deriv_by_col!(∂ⁿa∂xⁿ, a, device, n)
+    @info "@threaded derivative (no shared memory), n = $n:"
+    n == 0 && @info "    Latency = $(round(first_time - time; sigdigits = 3)) s"
+    print_time_and_bandwidth(device, 2 * sizeof(a), time)
+end
+
+# The following shared memory kernels will be benchmarked in PR #113.
+#=
+nth_deriv_by_col_shmem_1!(∂ⁿa∂xⁿ, a, device, n, ::Val{x_max}) where {x_max} =
+    ClimaComms.@cuda_sync device begin
+        ClimaComms.@threaded device begin
+            for y in axes(a, 2), x in @interdependent(axes(a, 1))
+                T = eltype(a)
+                a_col = ClimaComms.static_shared_memory_array(device, T, x_max)
+                @inbounds begin
+                    ClimaComms.@sync_interdependent a_col[x] = a[x, y]
+                    ClimaComms.@sync_interdependent ∂ⁿa∂xⁿ[x, y] =
+                        nth_deriv_along_axis1(a_col, n, x)
+                end
+            end
+        end
+    end
+
+nth_deriv_by_col_shmem_2!(∂ⁿa∂xⁿ, a, device, n, ::Val{x_max}) where {x_max} =
+    ClimaComms.@cuda_sync device begin
+        ClimaComms.@threaded device begin
+            for y in axes(a, 2), x in @interdependent(axes(a, 1))
+                T = eltype(a)
+                a_col = ClimaComms.static_shared_memory_array(device, T, x_max)
+                ∂ᵐa∂xᵐ_col = ClimaComms.static_shared_memory_array(device, T, x_max)
+                m = n ÷ 2
+                @inbounds begin
+                    ClimaComms.@sync_interdependent a_col[x] = a[x, y]
+                    ClimaComms.@sync_interdependent ∂ᵐa∂xᵐ_col[x] =
+                        nth_deriv_along_axis1(a_col, m, x)
+                    ClimaComms.@sync_interdependent ∂ⁿa∂xⁿ[x, y] =
+                        nth_deriv_along_axis1(∂ᵐa∂xᵐ_col, n - m, x)
+                end
+            end
+        end
+    end
+=#


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR extends the threaded macro to support lazy iterators from `Base` and `Base.Iterators`, such as `reverse`, `enumerate`, `zip`, and generator expressions. To enable threading over multiple iterators, support is also added for `Iterators.product`, with linear-to-Cartesian index conversion performed using standard integer division on CPUs and `Base.multiplicativeinverse` on GPUs. A new benchmarking script is also added to the test suite, which will allow us to monitor the performance of ClimaCore-like kernels.

One feature required for CliMA/ClimaAtmos.jl#3827 is the ability to parallelize over an iterator of the form `Iterators.partition(enumerate(Iterators.flatten(...)), autodiff_batch_size)`, which this PR will allow us to do.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
