### PR TITLE
Add device-agnostic API for querying available memory

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@ ClimaComms.jl Release Notes
 main
 -------
 
+v0.6.9
+-------
+- Added a device-agnostic API for querying available memory [PR 117](https://github.com/CliMA/ClimaComms.jl/pull/117).
+
 v0.6.8
 -------
 - Extended `@threaded` to work with multiple iterators and lazy iterators (e.g., `enumerate`, `zip`, and `Iterators.partition`), and modified the `threaded` function to make it equivalent to `@threaded` [PR 115](https://github.com/CliMA/ClimaComms.jl/pull/115).

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaComms"
 uuid = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
 authors = ["Kiran Pamnany <clima-software@caltech.edu>", "Simon Byrne <simonbyrne@caltech.edu>", "Charles Kawczynski <charliek@caltech.edu>", "Sriharsha Kandala <Sriharsha.kvs@gmail.com>", "Jake Bolewski <clima-software@caltech.edu>", "Gabriele Bozzola <gbozzola@caltech.edu>"]
-version = "0.6.8"
+version = "0.6.9"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/ext/ClimaCommsCUDAExt.jl
+++ b/ext/ClimaCommsCUDAExt.jl
@@ -35,6 +35,8 @@ Adapt.adapt_structure(
 ) = ClimaComms.CUDADevice()
 
 ClimaComms.array_type(::CUDADevice) = CUDA.CuArray
+ClimaComms.free_memory(::CUDADevice) = CUDA.free_memory()
+ClimaComms.total_memory(::CUDADevice) = CUDA.total_memory()
 ClimaComms.allowscalar(f, ::CUDADevice, args...; kwargs...) =
     CUDA.@allowscalar f(args...; kwargs...)
 

--- a/src/devices.jl
+++ b/src/devices.jl
@@ -103,6 +103,20 @@ Currently used to assign CUDADevices to MPI ranks.
 _assign_device(device, id) = nothing
 
 """
+    ClimaComms.free_memory(device)
+
+Bytes of memory that are currently available for allocation on the `device`.
+"""
+free_memory(::AbstractCPUDevice) = Sys.free_memory()
+
+"""
+    ClimaComms.total_memory(device)
+
+Bytes of memory that are theoretically available for allocation on the `device`.
+"""
+total_memory(::AbstractCPUDevice) = Sys.total_memory()
+
+"""
     @time f(args...; kwargs...)
 
 Device-flexible `@time`:


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR adds the device-agnostic functions `free_memory` and `total_memory`, which call their respective counterparts from `Sys` and `CUDA`. It also bumps the minor version so that this can be used for CliMA/ClimaAtmos.jl#3859.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
