### PR TITLE
ci: use dependabot to update julia packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# Julia support: https://discourse.julialang.org/t/psa-github-dependabot-now-supports-julia/134997
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "julia"
+    directories:
+      - "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    groups: # groups all julia package updates into a single PR
+      all-julia-packages:
+        patterns:
+          - "*"


### PR DESCRIPTION
Replaces CompatHelper with GitHub's native Dependabot support for Julia packages (announced [here](https://discourse.julialang.org/t/psa-github-dependabot-now-supports-julia/134997)).

Changes:
- Add Julia ecosystem to `.github/dependabot.yml`, covering the root environment
- Group all Julia package updates into a single weekly PR (every Wednesday)

See also: CliMA/ClimaAtmos.jl#4308