### PR TITLE
use newer TagBot

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -9,7 +9,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
-      - uses: JuliaRegistries/TagBot@v1.10.0
+      - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
I hope this will fix TagBot and close #138, but we won't know until we try to make another release.

I didn't see any major differences between this repo's TagBot yml and that of other repos where it does work (e.g. ClimaLand.jl) except for the TagBot version pin here.