### PR TITLE
Prevent dependabot from pushing doc previews

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -23,7 +23,10 @@ makedocs(
 deploydocs(
     repo = "github.com/CliMA/ClimaComms.jl.git",
     target = "build",
-    push_preview = true,
+    push_preview = all(
+        !isempty,
+        (get(ENV, "GITHUB_TOKEN", ""), get(ENV, "DOCUMENTER_KEY", "")),
+    ),
     devbranch = "main",
     forcepush = true,
 )


### PR DESCRIPTION
Without this commit, Dependabot will try to deploy docs and fail due to missing environment variables. See JuliaDocs/Documenter.jl#2048 which suggests the solution used in this commit.