### PR TITLE
Update JuliaFormatter to v2.10.1

### DIFF
--- a/.github/workflows/JuliaFormatter.yml
+++ b/.github/workflows/JuliaFormatter.yml
@@ -12,5 +12,5 @@ jobs:
     steps:
       - uses: julia-actions/julia-format@v4
         with:
-          version: '1'
+          version: '2.10.1'
           suggestion-label: 'format-suggest'


### PR DESCRIPTION
This PR updates JuliaFormatter to v2.10.1 and pins it. This is recommended by https://juliaeditorsupport.github.io/JuliaFormatter.jl/stable/status/#Pinning-the-JuliaFormatter-version.